### PR TITLE
Remove Rewards and Pause Redemptions

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -629,6 +629,16 @@ class HoojBot(app_commands.Group, name="hooj"):
         modal = AddRewardModal()
         await interaction.response.send_modal(modal)
 
+    @app_commands.command(name="remove_reward")
+    @app_commands.checks.has_role("Mod")
+    @app_commands.describe(name="Name of reward to remove")
+    async def remove_reward(self, interaction: Interaction, name: str):
+        """Removes channel reward for redemption"""
+        DB().remove_channel_reward(name)
+        await interaction.response.send_message(
+            f"Successfully removed {name}!", ephemeral=True
+        )
+
     @app_commands.command(name="redeem")
     async def redeem_reward(self, interaction: Interaction):
         """Redeem an available channel reward"""

--- a/bot.py
+++ b/bot.py
@@ -642,6 +642,12 @@ class HoojBot(app_commands.Group, name="hooj"):
     @app_commands.command(name="redeem")
     async def redeem_reward(self, interaction: Interaction):
         """Redeem an available channel reward"""
+        redemptions_allowed = DB().check_redemption_status()
+        if not redemptions_allowed:
+            return await interaction.response.send_message(
+                "Sorry! Reward redemptions are currently paused. Try again during stream!"
+            )
+
         rewards = DB().get_channel_rewards()
         user_points = DB().get_point_balance(interaction.user.id)
         view = RedeemRewardView(user_points, rewards, client)

--- a/bot.py
+++ b/bot.py
@@ -658,6 +658,29 @@ class HoojBot(app_commands.Group, name="hooj"):
             return_message += f"({reward.point_cost}) {reward.name}\n"
         await interaction.response.send_message(return_message, ephemeral=True)
 
+    @app_commands.command(name="allow_redemptions")
+    @app_commands.checks.has_role("Mod")
+    async def allow_redemptions(self, interaction: Interaction):
+        """Allow rewards to be redeemed"""
+        DB().allow_redemptions()
+        await interaction.response.send_message("Redemptions are now enabled")
+
+    @app_commands.command(name="pause_redemptions")
+    @app_commands.checks.has_role("Mod")
+    async def pause_redemptions(self, interaction: Interaction):
+        """Pause rewards from being redeemed"""
+        DB().pause_redemptions()
+        await interaction.response.send_message("Redemptions are now paused")
+
+    @app_commands.command(name="check_redemption_status")
+    async def check_redemption_status(self, interaction: Interaction):
+        """Check whether or not rewards are eligible to be redeemed"""
+        status = DB().check_redemption_status()
+        status_message = "allowed" if status else "paused"
+        await interaction.response.send_message(
+            f"Redemptions are currently {status_message}."
+        )
+
     @app_commands.command(name="point_balance")
     async def point_balance(self, interaction: Interaction):
         """Get your current number of channel points"""

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -14,6 +14,9 @@ from .channel_rewards import (
     add_channel_reward,
     get_channel_rewards,
     remove_channel_reward,
+    allow_redemptions,
+    pause_redemptions,
+    check_redemption_status,
 )
 from .models import Base, Raffle, RaffleEntry, RoleModifier, RaffleType
 from config import Config
@@ -338,3 +341,19 @@ class DB:
             list[ChannelReward]: All currently available channel rewards
         """
         return get_channel_rewards(self.session)
+
+    def allow_redemptions(self):
+        """Allow channel rewards to be redeemed"""
+        return allow_redemptions(self.session)
+
+    def pause_redemptions(self):
+        """Puase channel rewards from being redeemed"""
+        return pause_redemptions(self.session)
+
+    def check_redemption_status(self) -> bool:
+        """Check whether or not channel rewards are eligible for redemption
+
+        Returns:
+            bool: True if rewards are currently allowed
+        """
+        return check_redemption_status(self.session)

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -10,7 +10,11 @@ from .point_accrual import (
     get_point_balance,
     withdraw_points,
 )
-from .channel_rewards import add_channel_reward, get_channel_rewards
+from .channel_rewards import (
+    add_channel_reward,
+    get_channel_rewards,
+    remove_channel_reward,
+)
 from .models import Base, Raffle, RaffleEntry, RoleModifier, RaffleType
 from config import Config
 
@@ -318,6 +322,14 @@ class DB:
             point_cost (int): Number of ChannelPoints required to redeem
         """
         return add_channel_reward(name, point_cost, self.session)
+
+    def remove_channel_reward(self, name: str):
+        """Delete channel reward with matching name
+
+        Args:
+            name (str): Name of channel reward to delete
+        """
+        return remove_channel_reward(name, self.session)
 
     def get_channel_rewards(self):
         """Get all available channel rewards

--- a/db/channel_rewards.py
+++ b/db/channel_rewards.py
@@ -1,5 +1,5 @@
 from db.models import ChannelReward
-from sqlalchemy import select, update, insert
+from sqlalchemy import select, update, insert, delete
 from sqlalchemy.orm import sessionmaker
 
 
@@ -13,6 +13,17 @@ def add_channel_reward(name: str, point_cost: int, session: sessionmaker):
     """
     with session() as sess:
         sess.execute(insert(ChannelReward).values(name=name, point_cost=point_cost))
+
+
+def remove_channel_reward(name: str, session: sessionmaker):
+    """Delete channel reward with matching name
+
+    Args:
+        name (str): Name of channel reward to delete
+        session (sessionmaker): Open DB session
+    """
+    with session() as sess:
+        sess.execute(delete(ChannelReward).where(ChannelReward.name == name))
 
 
 def get_channel_rewards(session: sessionmaker) -> list[ChannelReward]:

--- a/db/channel_rewards.py
+++ b/db/channel_rewards.py
@@ -1,4 +1,4 @@
-from db.models import ChannelReward
+from db.models import ChannelReward, AllowRedemption
 from sqlalchemy import select, update, insert, delete
 from sqlalchemy.orm import sessionmaker
 
@@ -37,3 +37,62 @@ def get_channel_rewards(session: sessionmaker) -> list[ChannelReward]:
     """
     with session() as sess:
         return sess.query(ChannelReward).all()
+
+
+def allow_redemptions(session: sessionmaker):
+    """Allow channel rewards to be redeemed
+
+    Args:
+        session (sessionmaker): Open DB session
+    """
+    with session() as sess:
+        result = sess.query(AllowRedemption).first()
+
+        if result is None:
+            sess.execute(insert(AllowRedemption).values(allowed=True))
+            return
+
+        existing_row: AllowRedemption = result
+        sess.execute(
+            update(AllowRedemption)
+            .where(AllowRedemption.id == existing_row.id)
+            .values(allowed=True)
+        )
+
+
+def pause_redemptions(session: sessionmaker):
+    """Pause redemptions from being redeemed
+
+    Args:
+        session (sessionmaker): Open DB session
+    """
+    with session() as sess:
+        result = sess.query(AllowRedemption).first()
+
+        if result is None:
+            sess.execute(insert(AllowRedemption).values(allowed=False))
+            return
+
+        existing_row: AllowRedemption = result
+        sess.execute(
+            update(AllowRedemption)
+            .where(AllowRedemption.id == existing_row.id)
+            .values(allowed=False)
+        )
+
+
+def check_redemption_status(session: sessionmaker) -> bool:
+    """Check whether or not rewards are eligible for redemption
+
+    Args:
+        session (sessionmaker): Open DB session
+
+    Returns:
+        bool: True if rewards are currently allowed
+    """
+    with session() as sess:
+        result = sess.query(AllowRedemption).first()
+        if result is None:
+            return False
+
+        return result.allowed

--- a/db/models.py
+++ b/db/models.py
@@ -83,3 +83,13 @@ class ChannelReward(Base):
 
     def __repr__(self):
         return f"ChannelReward(id={self.id!r}, point_cost={self.point_cost!r}, name={self.name!r})"
+
+
+class AllowRedemption(Base):
+    __tablename__ = "allow_redemption"
+
+    id = Column(Integer, primary_key=True)
+    allowed = Column(Boolean, default=False)
+
+    def __repr__(self):
+        return f"AllowRedemption(id={self.id!r}, allowed={self.allowed!r})"


### PR DESCRIPTION
1. Add command to remove a previously configured reward via its name
2. Add `allow_redemptions`, `pause_redemptions` and `check_redemption_status` commands to ensure that channel rewards are only redeemable during stream
3. Only allow rewards to be redeemed if `cehck_redemption_status` is `True`