### PR TITLE
Prediction Fixes

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -981,6 +981,11 @@ class HoojBot(app_commands.Group, name="hooj"):
                 "No ongoing prediction!", ephemeral=True
             )
 
+        if DB().accepting_prediction_entries(interaction.guild_id):
+            return await interaction.response.send_message(
+                "Please close prediction from entries before refunding!", ephemeral=True
+            )
+
         option_one_entries = DB().get_prediction_entries_for_guess(
             interaction.guild_id, 0
         )
@@ -1005,6 +1010,12 @@ class HoojBot(app_commands.Group, name="hooj"):
         if not DB().has_ongoing_prediction(interaction.guild_id):
             return await interaction.response.send_message(
                 "No ongoing prediction!", ephemeral=True
+            )
+
+        if DB().accepting_prediction_entries(interaction.guild_id):
+            return await interaction.response.send_message(
+                "Please close prediction from entries before paying out!",
+                ephemeral=True,
             )
 
         option_one, option_two = DB().get_prediction_point_counts(interaction.guild_id)

--- a/bot.py
+++ b/bot.py
@@ -577,7 +577,7 @@ class PredictionView(View):
 
     async def end_prediction_button_onclick(self, interaction: Interaction):
         if not self.has_role("Mod", interaction):
-            interaction.response.send_message(
+            return await interaction.response.send_message(
                 "You must be a mod to do that!", ephemeral=True
             )
 


### PR DESCRIPTION
Commit titles summarize changes:
1. There was a bug where checking for the `Mod` role when closing a prediction did not return. This led to the prediction being closed even though the user did not have the correct permissions
2. Added command to refund a closed-but-not-complete prediction. This is a prediction where the `End Prediction` button has been pressed, but no payouts have been awarded.
3. Ensure that a prediction has been closed (i.e. `End Prediction` button has been pressed) before paying points out from `/hooj payout` or `/hooj refund_prediction`