### PR TITLE
fix good morning points count

### DIFF
--- a/db/point_accrual.py
+++ b/db/point_accrual.py
@@ -66,7 +66,7 @@ def accrue_morning_points(
             update(MorningPoints)
             .where(MorningPoints.user_id == user_id)
             .values(
-                points=morning_points.weekly_count + 1,
+                weekly_count=morning_points.weekly_count + 1,
                 timestamp=updated_timestamp,
             )
         )


### PR DESCRIPTION
points column does not exist in MorningPoints. The correct column is weekly_count. Tested locally.
![image](https://user-images.githubusercontent.com/115326516/212943051-99154ff0-5636-4a61-b0d4-1f6bff558128.png)
