### PR TITLE
Issue #37 - On Prediction creation send bets in threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,107 @@
-# Robo Banana
-
 Made for [Woohoojin](https://twitch.tv/woohoojin).
 
-A highly robust Discord management bot with a featureset designed around content creation and entertainment.
+
+#RoboBanana
+RoboBanana is a simple Twitch/Discord bot for managing and redeeming channel rewards using channel points.
+
+##Features
+Redeemable channel rewards with point cost and name.
+Pending rewards that can be completed or refunded by moderators.
+Automatic reward redemption with no need for a moderator to manually complete a reward.
+Technologies
+
+
+#Installation
+To run RoboBanana, you will need to create a config.ini file in the root directory and fill in the values exampled in the congif.ini.example
+
+###After setting up the .ini file, you can install the necessary Python packages using:
+
+pip install -r requirements.txt
+
+Run the bot using:
+python bot.py
+
+
+Usage
+Commands
+##Mod Commands
+    sync: This command can be used to synchronize the database with any external system, ensuring that all data is up-to-date.
+
+    gift: This command is used to gift a reward or points to a user.
+
+    start: This command can be used to start a new raffle, prediction, or any other similar activity.
+
+    end: This command can be used to end a raffle, prediction, or any other similar activity.
+
+    add_reward: This command is used to add a new reward to the system.
+
+    remove_reward: This command can be used to remove a reward from the system.
+
+    allow_redemptions: This command can be used to enable the redemption of rewards.
+
+    pause_redemptions: This command can be used to pause the redemption of rewards.
+
+    check_redemption_status: This command can be used to check the status of a reward redemption.
+
+    start_prediction: This command can be used to start a new prediction.
+
+    refund_prediction: This command can be used to refund a prediction.
+
+    payout_prediction: This command can be used to payout a prediction.
+
+    redo_payout: This command can be used to redo a payout.
+
+    give_points: This command can be used to give points to a user.
+
+    good_morning_count: This command can be used to count the number of times a user has said "good morning" in a channel.
+
+    good_morning_reward: This command can be used to reward a user for saying "good morning" a certain number of times in a channel.
+
+    good_morning_reset: This command can be used to reset the "good morning" count for a user.
+
+    good_morning_increment: This command can be used to increment the "good morning" count for a user.
+
+    remove_raffle_winner: This command can be used to remove a winner from a raffle.
+
+##User Commands
+
+    redeem_reward: This command allows a user to redeem an available channel reward. It first checks if reward redemptions are allowed, and if not, it sends a message indicating that redemptions are currently paused. If redemptions are allowed, it retrieves the available rewards and the user's current point balance from the database, and sends a RedeemRewardView containing the rewards and point balance to the user.
+
+    list_rewards: This command lists all the available channel rewards. It retrieves the rewards from the database and constructs a message string with the name and point cost of each reward. It then sends this message to the user.
+
+    point_balance: This command allows a user to check their current number of channel points. It retrieves the user's point balance from the database and sends a message indicating the user's current point balance to the user.
+
+    bet: This command allows a user to place a bet on the currently ongoing prediction. It takes two arguments: choice and points. Choice is the user's chosen PredictionChoice (either A or B), and points is the number of channel points the user wants to bet. It then creates a new prediction entry in the database with the user's bet, choice, and interaction ID, and sends a message confirming that the user's vote has been cast.
+
+    good_morning: This command allows a user to say "good morning" in a designated channel. It accrues "good morning points" for the user, and sends a message acknowledging the user's good morning.
+
+    good_morning_points: This command allows a user to check their current number of "good morning points". It retrieves the user's good morning points from the database and sends a message indicating the user's current good morning points to the user.
+
+##Manager Commands 
+
+    flag_vod: Flags a VOD (video on demand) as approved, rejected, or complete. It takes one argument vod_type which is of type VODType (an enum with three possible values - approved, rejected, or complete). The command can only be executed by users with the "Community Manager" role. 
+
+
+
+
+#Project Structure
+##The project is structured as follows:
+
+    commands/: This directory contains files defining all the bot's commands, separated by role.
+
+    controllers/: This directory contains files defining the business logic of the bot. Each controller could be responsible for handling a specific feature or set of related features, such as managing points or handling predictions. 
+
+    db/: This contains the models files, as described. The models.py file defines the schema for the bot's database tables. This folder also includes the interactions for the database for other files to use.
+
+    views/: Contains the view classes used to render Discord components.
+        
+    config.py: Contains the configuration values loaded from the .ini file.
+
+    bot.py: Contains the main bot code.
+
+    requirements.txt: Contains the list of required Python packages.
+
+RoboBanana is currently limited to a single Discord server and Twitch channel.
 
 Hosted on [Digital Ocean](https://m.do.co/c/4ec28adf00bb)
 

--- a/README.md
+++ b/README.md
@@ -8,18 +8,21 @@ RoboBanana is a simple Twitch/Discord bot for managing and redeeming channel rew
 Redeemable channel rewards with point cost and name.
 Pending rewards that can be completed or refunded by moderators.
 Automatic reward redemption with no need for a moderator to manually complete a reward.
-Technologies
+
+
 
 
 ## Installation
 To run RoboBanana, you will need to create a config.ini file in the root directory and fill in the values exampled in the congif.ini.example
 
-###After setting up the .ini file, you can install the necessary Python packages using:
+After setting up the .ini file, you can install the necessary Python packages using:
 
 pip install -r requirements.txt
 
 Run the bot using:
 python bot.py
+
+Instalation and configuration of a SQL database will be required
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 Made for [Woohoojin](https://twitch.tv/woohoojin).
 
 
-#RoboBanana
+# RoboBanana
 RoboBanana is a simple Twitch/Discord bot for managing and redeeming channel rewards using channel points.
 
-##Features
+## Features
 Redeemable channel rewards with point cost and name.
 Pending rewards that can be completed or refunded by moderators.
 Automatic reward redemption with no need for a moderator to manually complete a reward.
 Technologies
 
 
-#Installation
+## Installation
 To run RoboBanana, you will need to create a config.ini file in the root directory and fill in the values exampled in the congif.ini.example
 
 ###After setting up the .ini file, you can install the necessary Python packages using:
@@ -22,9 +22,9 @@ Run the bot using:
 python bot.py
 
 
-Usage
-Commands
-##Mod Commands
+## Usage
+### Commands
+### Mod Commands
     sync: This command can be used to synchronize the database with any external system, ensuring that all data is up-to-date.
 
     gift: This command is used to gift a reward or points to a user.
@@ -63,7 +63,7 @@ Commands
 
     remove_raffle_winner: This command can be used to remove a winner from a raffle.
 
-##User Commands
+### User Commands
 
     redeem_reward: This command allows a user to redeem an available channel reward. It first checks if reward redemptions are allowed, and if not, it sends a message indicating that redemptions are currently paused. If redemptions are allowed, it retrieves the available rewards and the user's current point balance from the database, and sends a RedeemRewardView containing the rewards and point balance to the user.
 
@@ -77,15 +77,15 @@ Commands
 
     good_morning_points: This command allows a user to check their current number of "good morning points". It retrieves the user's good morning points from the database and sends a message indicating the user's current good morning points to the user.
 
-##Manager Commands 
+### Manager Commands 
 
     flag_vod: Flags a VOD (video on demand) as approved, rejected, or complete. It takes one argument vod_type which is of type VODType (an enum with three possible values - approved, rejected, or complete). The command can only be executed by users with the "Community Manager" role. 
 
 
 
 
-#Project Structure
-##The project is structured as follows:
+## Project Structure
+### The project is structured as follows:
 
     commands/: This directory contains files defining all the bot's commands, separated by role.
 

--- a/controllers/prediction_controller.py
+++ b/controllers/prediction_controller.py
@@ -260,6 +260,8 @@ class PredictionController:
         channel_id = DB().get_prediction_channel_id(prediction_id)
         message_id = DB().get_prediction_message_id(prediction_id)
 
+        thread_id = DB().get_prediction_thread_id(prediction_id)
+
         # We'll use this prediction summary for the reply message
         prediction_summary = DB().get_prediction_summary(prediction_id)
         Thread(target=publish_update, args=(prediction_summary,)).start()
@@ -272,7 +274,10 @@ class PredictionController:
         prediction_message = await client.get_channel(channel_id).fetch_message(
             message_id
         )
-        await prediction_message.reply(
+
+        prediction_thread = client.get_channel(thread_id)
+
+        await prediction_thread.send(
             f"{interaction.user.mention} bet {channel_points} hooj bucks on {chosen_option}"
         )
         return True
@@ -282,6 +287,7 @@ class PredictionController:
         guild_id: int,
         channel_id: int,
         message_id: str,
+        thread_id: str,
         description: str,
         option_one: str,
         option_two: str,
@@ -291,6 +297,7 @@ class PredictionController:
             guild_id,
             channel_id,
             message_id,
+            thread_id,
             description,
             option_one,
             option_two,

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -29,6 +29,7 @@ from .predictions import (
     get_ongoing_prediction_id,
     get_prediction_point_counts,
     get_prediction_message_id,
+    get_prediction_thread_id,
     get_prediction_channel_id,
     get_prediction_summary,
     get_user_prediction_entry,
@@ -491,6 +492,7 @@ class DB:
         guild_id: int,
         channel_id: int,
         message_id: str,
+        thread_id: str,
         description: str,
         option_one: str,
         option_two: str,
@@ -501,6 +503,7 @@ class DB:
         Args:
             guild_id (int): Discord Guild ID initiating prediction
             message_id (str): Discord ID for message initiating prediction
+            thread_id (str): Thread ID from the Message initiatin the prediction
             description (str): Description of what viewers are trying to predict
             option_one (str): First option that users can vote for
             option_two (str): Second option that users can vote for
@@ -510,6 +513,7 @@ class DB:
             guild_id,
             channel_id,
             message_id,
+            thread_id,
             description,
             option_one,
             option_two,
@@ -577,6 +581,17 @@ class DB:
             Optional(int): ID of message which started prediction
         """
         return get_prediction_message_id(prediction_id, self.session)
+    
+    def get_prediction_thread_id(self, prediction_id: int) -> Optional[int]:
+        """Get thread ID from the thread of initial prediction start
+
+        Args:
+            prediction_id (int): ID of Prediction to retrieve starting message for
+
+        Returns:
+            Optional(int): ID of message which started prediction
+        """
+        return get_prediction_thread_id(prediction_id, self.session)
 
     def get_prediction_channel_id(self, prediction_id: int) -> Optional[int]:
         """Get channel ID of an ongoing prediction

--- a/db/models.py
+++ b/db/models.py
@@ -148,6 +148,7 @@ class Prediction(Base):
     guild_id = Column(BigInteger, nullable=False)
     channel_id = Column(BigInteger, nullable=False)
     message_id = Column(BigInteger, nullable=False, unique=True)
+    thread_id = Column(BigInteger, nullable=False, unique=True)
     accepting_entries = Column(Boolean, nullable=False, default=True)
     ended = Column(Boolean, nullable=False, default=False)
     start_time = Column(DateTime, default=func.now())

--- a/db/predictions.py
+++ b/db/predictions.py
@@ -9,6 +9,7 @@ def create_prediction(
     guild_id: int,
     channel_id: int,
     message_id: int,
+    thread_id: str,
     description: str,
     option_one: str,
     option_two: str,
@@ -24,6 +25,7 @@ def create_prediction(
                 guild_id=guild_id,
                 channel_id=channel_id,
                 message_id=message_id,
+                thread_id=thread_id,
                 description=description,
                 option_one=option_one,
                 option_two=option_two,
@@ -102,6 +104,20 @@ def get_prediction_message_id(
     with session() as sess:
         stmt = (
             select(Prediction.message_id).where(Prediction.id == prediction_id).limit(1)
+        )
+        result = sess.execute(stmt).one()
+
+    if len(result) == 0:
+        return None
+
+    return result[0]
+
+def get_prediction_thread_id(
+    prediction_id: int, session: sessionmaker
+) -> Optional[int]:
+    with session() as sess:
+        stmt = (
+            select(Prediction.thread_id).where(Prediction.id == prediction_id).limit(1)
         )
         result = sess.execute(stmt).one()
 

--- a/views/predictions/close_prediction_view.py
+++ b/views/predictions/close_prediction_view.py
@@ -46,6 +46,8 @@ class ClosePredictionView(View):
         prediction_id = DB().get_ongoing_prediction_id(interaction.guild_id)
         prediction_message_id = DB().get_prediction_message_id(prediction_id)
         prediction_channel_id = DB().get_prediction_channel_id(prediction_id)
+        prediction_thread_id = DB().get_prediction_thread_id(prediction_id)
+
         prediction_message = await self.client.get_channel(
             prediction_channel_id
         ).fetch_message(prediction_message_id)
@@ -57,6 +59,9 @@ class ClosePredictionView(View):
         )
         await prediction_message.reply("Prediction closed!")
         await interaction.response.send_message("Prediction closed!", ephemeral=True)
+
+        prediction_thread = self.client.get_channel(prediction_thread_id)
+        await prediction_thread.delete()
 
         await self.client.get_channel(PENDING_REWARDS_CHAT_ID).send(
             "Payout Prediction!",

--- a/views/predictions/create_predictions_modal.py
+++ b/views/predictions/create_predictions_modal.py
@@ -56,15 +56,20 @@ class CreatePredictionModal(Modal, title="Start new prediction"):
         await interaction.response.send_message("Creating prediction...")
 
         end_time = datetime.now() + timedelta(seconds=duration)
+        
         prediction_message = await interaction.original_response()
+
+        prediction_thread = await prediction_message.create_thread(name="Prediction Thread")
+
         await PredictionController.create_prediction(
             interaction.guild_id,
             interaction.channel.id,
             prediction_message.id,
+            prediction_thread.id,
             self.description.value,
             self.option_one.value,
             self.option_two.value,
-            end_time,
+            end_time
         )
         prediction_embed = PredictionEmbed(
             interaction.guild_id, self.description.value, end_time


### PR DESCRIPTION
Updating prediction:
Issue: Due to the increase in viewership the predictions take over the chat while being run

Solution: Move the prediction notification to a thread off of the main prediction message.
In order to track the the thread I have added thread_id column to the prediction table 
- was unable to find a solution that would not result in excessive calls to discord

Once the prediction is ended, the thread is deleted
