### PR TITLE
[Fix] "Interaction failed" visual error

### DIFF
--- a/views/predictions/payout_prediction_view.py
+++ b/views/predictions/payout_prediction_view.py
@@ -44,7 +44,7 @@ class PayoutPredictionView(View):
         self.option_one_button.disabled = True
         self.option_two_button.disabled = True
         self.refund_button.disabled = True
-        await interaction.message.edit(content="", view=self)
+        await interaction.response.edit_message(content="", view=self)
 
     async def option_two_onclick(self, interaction: Interaction):
         await PredictionController.payout_prediction(
@@ -53,11 +53,11 @@ class PayoutPredictionView(View):
         self.option_one_button.disabled = True
         self.option_two_button.disabled = True
         self.refund_button.disabled = True
-        await interaction.message.edit(content="", view=self)
+        await interaction.response.edit_message(content="", view=self)
 
     async def refund_onclick(self, interaction: Interaction):
         await PredictionController.refund_prediction(interaction, self.client)
         self.option_one_button.disabled = True
         self.option_two_button.disabled = True
         self.refund_button.disabled = True
-        await interaction.message.edit(content="", view=self)
+        await interaction.response.edit_message(content="", view=self)


### PR DESCRIPTION
- Small pull request that changes interactions that don't use ``interaction.response`` to use them instead of directly editing the interaction's message.
- No logic is changed other than that the user won't get an interaction failed error on their discord client (I noticed the error in woohoojin's stream today).
- This change is only done for these three methods because they are the only methods that didn't have an ``interaction.response`` call (they can only be used once per method).