### PR TITLE
Pull vod-commands out into separate command Group

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -18,6 +18,7 @@ from commands.mod_commands import ModCommands
 from commands.viewer_commands import ViewerCommands
 from commands.manager_commands import ManagerCommands
 from commands.reaction_commands import ReactionCommands
+from commands.vod_commands import VodCommands
 from config import Config
 from controllers.reaction_controller import ReactionController
 from controllers.sub_controller import SubController
@@ -41,6 +42,8 @@ CROWD_MUTE_DURATION = int(Config.CONFIG["Discord"]["CrowdMuteDuration"])
 FOSSA_BOT_ID = 488164251249279037
 SERVER_SUBSCRIPTION_MESSAGE_TYPE = 25
 MAX_CHARACTER_LENGTH = 200
+
+LOG = logging.getLogger(__name__)
 
 
 class RaffleBot(Client):
@@ -192,6 +195,7 @@ async def main():
         tree.add_command(ViewerCommands(tree, client))
         tree.add_command(ManagerCommands(tree, client))
         tree.add_command(ReactionCommands(tree, client))
+        tree.add_command(VodCommands(tree, client))
         await client.start(Config.CONFIG["Discord"]["Token"])
 
 

--- a/commands/mod_commands.py
+++ b/commands/mod_commands.py
@@ -25,7 +25,6 @@ HOOJ_DISCORD_ID = 82969926125490176
 POINTS_AUDIT_CHANNEL = int(Config.CONFIG["Discord"]["PointsAuditChannel"])
 
 AUTH_TOKEN = Config.CONFIG["Server"]["AuthToken"]
-PUBLISH_URL = "http://localhost:3000/publish-vod"
 PUBLISH_POLL_URL = "http://localhost:3000/publish-poll"
 PUBLISH_TIMER_URL = "http://localhost:3000/publish-timer"
 
@@ -135,45 +134,6 @@ class ModCommands(app_commands.Group, name="mod"):
         ).start()
 
         await interaction.response.send_message("Poll created!", ephemeral=True)
-
-    @app_commands.command(name="vod")
-    @app_commands.checks.has_role("Mod")
-    @app_commands.describe(username="username")
-    @app_commands.describe(riotid="riotid")
-    @app_commands.describe(rank="rank")
-    async def vod(
-        self, interaction: Interaction, username: str, riotid: str, rank: str
-    ) -> None:
-        """Start a VOD review for the given username"""
-        Thread(
-            target=publish_update,
-            args=(
-                username,
-                riotid,
-                rank,
-                False,
-            ),
-        ).start()
-
-        await interaction.response.send_message("Username event sent!", ephemeral=True)
-
-    @app_commands.command(name="complete")
-    @app_commands.checks.has_role("Mod")
-    async def complete(self, interaction: Interaction) -> None:
-        """Start a VOD review for the given username"""
-        Thread(
-            target=publish_update,
-            args=(
-                "",
-                "",
-                "",
-                True,
-            ),
-        ).start()
-
-        await interaction.response.send_message(
-            "VOD Complete Event sent!", ephemeral=True
-        )
 
     @app_commands.command(name="gift")
     @app_commands.checks.has_role("Mod")
@@ -479,22 +439,6 @@ class ModCommands(app_commands.Group, name="mod"):
             return
 
         await interaction.response.send_message("Winner removed!")
-
-
-def publish_update(username, riotid, rank, complete):
-    payload = {
-        "username": username,
-        "riotid": riotid,
-        "rank": rank,
-        "complete": complete,
-    }
-
-    response = requests.post(
-        url=PUBLISH_URL, json=payload, headers={"x-access-token": AUTH_TOKEN}
-    )
-
-    if response.status_code != 200:
-        LOG.error(f"Failed to publish updated prediction summary: {response.text}")
 
 
 def publish_poll(title, option_one, option_two, option_three, option_four):

--- a/commands/vod_commands.py
+++ b/commands/vod_commands.py
@@ -1,0 +1,72 @@
+from discord import app_commands, Interaction, Client, User
+from threading import Thread
+from config import Config
+import requests
+import logging
+
+PUBLISH_URL = "http://localhost:3000/publish-vod"
+LOG = logging.getLogger(__name__)
+AUTH_TOKEN = Config.CONFIG["Server"]["AuthToken"]
+
+
+@app_commands.guild_only()
+class VodCommands(app_commands.Group, name="vod"):
+    def __init__(self, tree: app_commands.CommandTree, client: Client) -> None:
+        super().__init__()
+        self.tree = tree
+        self.client = client
+
+    @app_commands.command(name="start")
+    @app_commands.checks.has_role("Mod")
+    @app_commands.describe(username="username")
+    @app_commands.describe(riotid="riotid")
+    @app_commands.describe(rank="rank")
+    async def vod(
+        self, interaction: Interaction, username: str, riotid: str, rank: str
+    ) -> None:
+        """Start a VOD review for the given username"""
+        Thread(
+            target=publish_update,
+            args=(
+                username,
+                riotid,
+                rank,
+                False,
+            ),
+        ).start()
+
+        await interaction.response.send_message("VOD start event sent!", ephemeral=True)
+
+    @app_commands.command(name="end")
+    @app_commands.checks.has_role("Mod")
+    async def complete(self, interaction: Interaction) -> None:
+        """Start a VOD review for the given username"""
+        Thread(
+            target=publish_update,
+            args=(
+                "",
+                "",
+                "",
+                True,
+            ),
+        ).start()
+
+        await interaction.response.send_message(
+            "VOD Complete Event sent!", ephemeral=True
+        )
+
+
+def publish_update(username, riotid, rank, complete):
+    payload = {
+        "username": username,
+        "riotid": riotid,
+        "rank": rank,
+        "complete": complete,
+    }
+
+    response = requests.post(
+        url=PUBLISH_URL, json=payload, headers={"x-access-token": AUTH_TOKEN}
+    )
+
+    if response.status_code != 200:
+        LOG.error(f"Failed to publish updated prediction summary: {response.text}")


### PR DESCRIPTION
## Motivation
Currently, we’re hitting our maximum number of commands allowed for `/mod`. Refactor command tree to be grouped by function (i.e. `/prediction`, `/vod`, etc)

### Trello Ticket
https://trello.com/c/oK0jGsmL

## Testing
Ensured that updates are still published to server after changes
<img width="960" alt="image" src="https://github.com/crscillitoe/RoboBanana/assets/17772186/f3ad95d2-b2e7-4e11-b0cf-09346e3bbb27">
