### PR TITLE
Good morning can only occur between 9:00AM and 11:30AM PST

### DIFF
--- a/controllers/good_morning_controller.py
+++ b/controllers/good_morning_controller.py
@@ -43,7 +43,10 @@ class GoodMorningController:
         end_time_epoch = epochtime(GoodMorningController.to_utc(end_time).timetuple())
         start_time_str = f"<t:{start_time_epoch:.0f}:t>"
         end_time_str = f"<t:{end_time_epoch:.0f}:t>"
-        return f"You can only say good morning between {start_time_str} and {end_time_str}!"
+        return (
+            f"You can only say good morning between {start_time_str} and"
+            f" {end_time_str}!"
+        )
 
     async def accrue_good_morning(interaction: Interaction):
         if not GoodMorningController.valid_accrual_time(interaction.created_at):


### PR DESCRIPTION
## Motivation
Christian wants to be able to do sub-only chat without users being required to do their Good Mornings in the stream chat. Remove stream-chat restriction on the command and lock the command to stream times

## Implementation
* Check if the interaction was created during the time window of 9:00AM and 11:30AM PST
* If yes, perform the Good Morning logic
* If no, respond to the interaction with an embedded datetime object for the user to understand when (in their timezone) they are allowed to use the command