### PR TITLE
Added timed delay for Robomojis

### DIFF
--- a/commands/reaction_commands.py
+++ b/commands/reaction_commands.py
@@ -23,5 +23,6 @@ class ReactionCommands(app_commands.Group, name="reactions"):
     @app_commands.checks.has_role("Mod")
     @app_commands.describe(delay_time="Delay time in seconds for Robomojis")
     async def set_emoji_reaction_delay(self, interaction: Interaction, delay_time: int):
+        """Sets delay time in seconds between Robomoji reactions for users"""
         result = DB().set_emoji_reaction_delay(delay_time)
         await interaction.response.send_message(f"Robomoji delay time set to {result} seconds!")

--- a/commands/reaction_commands.py
+++ b/commands/reaction_commands.py
@@ -19,9 +19,9 @@ class ReactionCommands(app_commands.Group, name="reactions"):
         toggle_desc = "ON" if result else "OFF"
         await interaction.response.send_message(f"Reaction toggled {toggle_desc}!")
 
-    @app_commands.command(name="set_emoji_delay")
+    @app_commands.command(name="set_emoji_reaction_delay")
     @app_commands.checks.has_role("Mod")
     @app_commands.describe(delay_time="Delay time in seconds for Robomojis")
-    async def set_emoji_delay(self, interaction: Interaction, delay_time: int):
-        result = DB().set_emoji_delay(delay_time)
+    async def set_emoji_reaction_delay(self, interaction: Interaction, delay_time: int):
+        result = DB().set_emoji_reaction_delay(delay_time)
         await interaction.response.send_message(f"Robomoji delay time set to {result} seconds!")

--- a/commands/reaction_commands.py
+++ b/commands/reaction_commands.py
@@ -18,3 +18,10 @@ class ReactionCommands(app_commands.Group, name="reactions"):
         result = DB().toggle_emoji_reaction(user.id, emoji)
         toggle_desc = "ON" if result else "OFF"
         await interaction.response.send_message(f"Reaction toggled {toggle_desc}!")
+
+    @app_commands.command(name="set_emoji_delay")
+    @app_commands.checks.has_role("Mod")
+    @app_commands.describe(delay_time="Delay time in seconds for Robomojis")
+    async def set_emoji_delay(self, interaction: Interaction, delay_time: int):
+        result = DB().set_emoji_delay(delay_time)
+        await interaction.response.send_message(f"Robomoji delay time set to {result} seconds!")

--- a/controllers/reaction_controller.py
+++ b/controllers/reaction_controller.py
@@ -5,7 +5,9 @@ import logging
 
 LOG = logging.getLogger(__name__)
 
-DEFAULT_EMOJI_REACTION_DELAY = 15  # Default delay for Robomoji reactions if not set manually
+DEFAULT_EMOJI_REACTION_DELAY = (
+    15  # Default delay for Robomoji reactions if not set manually
+)
 
 
 class ReactionController:
@@ -24,9 +26,14 @@ class ReactionController:
 
         last_reaction_datetime = DB().get_emoji_reaction_last_used(message.author.id)
 
-        robomoji_allowed_datetime = last_reaction_datetime or datetime.now() + timedelta(seconds=emoji_delay_seconds) # handles case on user's first message in new system
+        robomoji_allowed_datetime = (
+            last_reaction_datetime or datetime.now()
+        ) + timedelta(
+            seconds=emoji_delay_seconds
+        )  # handles case on user's first message in new system
         if (
-            last_reaction_datetime == None # handles case on user's first message in new system
+            last_reaction_datetime
+            == None  # handles case on user's first message in new system
             or robomoji_allowed_datetime <= datetime.now()
         ):
             for emoji in emojis:

--- a/controllers/reaction_controller.py
+++ b/controllers/reaction_controller.py
@@ -7,7 +7,7 @@ class ReactionController:
     @staticmethod
     async def apply_reactions(message: Message):
         emojis = DB().get_reactions_for_user(message.author.id)
-        if len(emojis) != 0:
+        if len(emojis) != 0: # prevents further DB calls if user does not have any Robomojis
             emoji_delay_seconds = DB().get_emoji_reaction_delay()
             last_reaction_datetime = DB().get_emoji_reaction_last_used(message.author.id)
             robomoji_allowed_datetime = last_reaction_datetime + timedelta(seconds=emoji_delay_seconds)

--- a/controllers/reaction_controller.py
+++ b/controllers/reaction_controller.py
@@ -1,10 +1,17 @@
 from discord import Message
 from db import DB
+from datetime import datetime, timedelta
 
 
 class ReactionController:
     @staticmethod
     async def apply_reactions(message: Message):
         emojis = DB().get_reactions_for_user(message.author.id)
-        for emoji in emojis:
-            await message.add_reaction(emoji)
+        if len(emojis) != 0:
+            emoji_delay_seconds = DB().get_emoji_delay()
+            last_reaction_datetime = DB().get_emoji_last_used(message.author.id)
+            robomoji_allowed_datetime = last_reaction_datetime + timedelta(seconds=emoji_delay_seconds)
+            if (robomoji_allowed_datetime <= datetime.now()):
+                for emoji in emojis:
+                    await message.add_reaction(emoji)
+                DB().set_emoji_last_used(message.author.id, datetime.now())

--- a/controllers/reaction_controller.py
+++ b/controllers/reaction_controller.py
@@ -1,17 +1,34 @@
 from discord import Message
 from db import DB
 from datetime import datetime, timedelta
+import logging
+
+LOG = logging.getLogger(__name__)
+
+DEFAULT_EMOJI_REACTION_DELAY = 15  # Default delay for Robomoji reactions if not set manually
 
 
 class ReactionController:
     @staticmethod
     async def apply_reactions(message: Message):
         emojis = DB().get_reactions_for_user(message.author.id)
-        if len(emojis) != 0: # prevents further DB calls if user does not have any Robomojis
-            emoji_delay_seconds = DB().get_emoji_reaction_delay()
-            last_reaction_datetime = DB().get_emoji_reaction_last_used(message.author.id)
-            robomoji_allowed_datetime = last_reaction_datetime + timedelta(seconds=emoji_delay_seconds)
-            if (robomoji_allowed_datetime <= datetime.now()):
-                for emoji in emojis:
-                    await message.add_reaction(emoji)
-                DB().set_emoji_reaction_last_used(message.author.id, datetime.now())
+        if len(emojis) == 0:
+            return  # prevents further DB calls if user does not have any Robomojis
+
+        db_emoji_delay = DB().get_emoji_reaction_delay()
+        emoji_delay_seconds = (
+            db_emoji_delay
+            if db_emoji_delay != None
+            else DEFAULT_EMOJI_REACTION_DELAY  # handles case if delay has not been set yet
+        )
+
+        last_reaction_datetime = DB().get_emoji_reaction_last_used(message.author.id)
+
+        robomoji_allowed_datetime = last_reaction_datetime or datetime.now() + timedelta(seconds=emoji_delay_seconds) # handles case on user's first message in new system
+        if (
+            last_reaction_datetime == None # handles case on user's first message in new system
+            or robomoji_allowed_datetime <= datetime.now()
+        ):
+            for emoji in emojis:
+                await message.add_reaction(emoji)
+            DB().set_emoji_reaction_last_used(message.author.id, datetime.now())

--- a/controllers/reaction_controller.py
+++ b/controllers/reaction_controller.py
@@ -8,10 +8,10 @@ class ReactionController:
     async def apply_reactions(message: Message):
         emojis = DB().get_reactions_for_user(message.author.id)
         if len(emojis) != 0:
-            emoji_delay_seconds = DB().get_emoji_delay()
-            last_reaction_datetime = DB().get_emoji_last_used(message.author.id)
+            emoji_delay_seconds = DB().get_emoji_reaction_delay()
+            last_reaction_datetime = DB().get_emoji_reaction_last_used(message.author.id)
             robomoji_allowed_datetime = last_reaction_datetime + timedelta(seconds=emoji_delay_seconds)
             if (robomoji_allowed_datetime <= datetime.now()):
                 for emoji in emojis:
                     await message.add_reaction(emoji)
-                DB().set_emoji_last_used(message.author.id, datetime.now())
+                DB().set_emoji_reaction_last_used(message.author.id, datetime.now())

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -65,10 +65,10 @@ from .channel_rewards import (
 from .emoji_reactions import (
     get_reactions_for_user,
     toggle_emoji_reaction,
-    get_emoji_delay,
-    set_emoji_delay,
-    get_emoji_last_used,
-    set_emoji_last_used,
+    get_emoji_reaction_delay,
+    set_emoji_reaction_delay,
+    get_emoji_reaction_last_used,
+    set_emoji_reaction_last_used,
 )
 from .models import (
     Base,
@@ -737,23 +737,23 @@ class DB:
         """
         return get_reactions_for_user(user_id, self.session)
 
-    def get_emoji_delay(self):
+    def get_emoji_reaction_delay(self):
         """Get Robomoji delay time
 
         Returns:
             int: Delay time in seconds for Robomojis
         """
-        return get_emoji_delay(self.session)
+        return get_emoji_reaction_delay(self.session)
 
-    def set_emoji_delay(self, delay_time: int):
+    def set_emoji_reaction_delay(self, delay_time: int):
         """Set Robomoji delay time
 
         Args:
             delay_time (int): Delay time in seconds for Robomojis
         """
-        return set_emoji_delay(delay_time, self.session)
+        return set_emoji_reaction_delay(delay_time, self.session)
 
-    def get_emoji_last_used(
+    def get_emoji_reaction_last_used(
         self,
         user_id: int,
     ):
@@ -766,9 +766,9 @@ class DB:
         Returns:
             DateTime: DateTime of last Robomoji reaction for given user
         """
-        return get_emoji_last_used(user_id, self.session)
+        return get_emoji_reaction_last_used(user_id, self.session)
 
-    def set_emoji_last_used(self, user_id: int, last_used: DateTime):
+    def set_emoji_reaction_last_used(self, user_id: int, last_used: DateTime):
         """
         Set DateTime of last Robomoji reaction
 
@@ -776,7 +776,7 @@ class DB:
             user_id (int): Discord User ID to add reaction to
             last_used (DateTime):  DateTime of most recently used Robomoji reaction
         """
-        return set_emoji_last_used(user_id, last_used, self.session)
+        return set_emoji_reaction_last_used(user_id, last_used, self.session)
 
     def set_temprole(
         self, user_id: int, role_id: int, guild_id: int, expiration: datetime

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from discord import Role
-from sqlalchemy import create_engine, select, update, insert, func
+from sqlalchemy import create_engine, select, update, insert, func, DateTime
 from sqlalchemy.orm import sessionmaker
 from typing import Optional
 
@@ -62,7 +62,14 @@ from .channel_rewards import (
     pause_redemptions,
     check_redemption_status,
 )
-from .emoji_reactions import get_reactions_for_user, toggle_emoji_reaction
+from .emoji_reactions import (
+    get_reactions_for_user,
+    toggle_emoji_reaction,
+    get_emoji_delay,
+    set_emoji_delay,
+    get_emoji_last_used,
+    set_emoji_last_used,
+)
 from .models import (
     Base,
     Prediction,
@@ -729,6 +736,47 @@ class DB:
             list[str]: Emojis to apply to messages
         """
         return get_reactions_for_user(user_id, self.session)
+
+    def get_emoji_delay(self):
+        """Get Robomoji delay time
+
+        Returns:
+            int: Delay time in seconds for Robomojis
+        """
+        return get_emoji_delay(self.session)
+
+    def set_emoji_delay(self, delay_time: int):
+        """Set Robomoji delay time
+
+        Args:
+            delay_time (int): Delay time in seconds for Robomojis
+        """
+        return set_emoji_delay(delay_time, self.session)
+
+    def get_emoji_last_used(
+        self,
+        user_id: int,
+    ):
+        """
+        Get DateTime of last Robomoji reaction
+
+        Args:
+            user_id (int): Discord User ID to add reaction to
+
+        Returns:
+            DateTime: DateTime of last Robomoji reaction for given user
+        """
+        return get_emoji_last_used(user_id, self.session)
+
+    def set_emoji_last_used(self, user_id: int, last_used: DateTime):
+        """
+        Set DateTime of last Robomoji reaction
+
+        Args:
+            user_id (int): Discord User ID to add reaction to
+            last_used (DateTime):  DateTime of most recently used Robomoji reaction
+        """
+        return set_emoji_last_used(user_id, last_used, self.session)
 
     def set_temprole(
         self, user_id: int, role_id: int, guild_id: int, expiration: datetime

--- a/db/emoji_reactions.py
+++ b/db/emoji_reactions.py
@@ -1,8 +1,9 @@
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy import select, delete, insert
+from sqlalchemy import select, delete, insert, update, DateTime
 import logging
+from datetime import datetime, timedelta
 
-from db.models import EmojiReactions
+from db.models import EmojiReactions, EmojiReactionDelay, EmojiReactionTimes
 
 LOG = logging.getLogger(__name__)
 
@@ -49,3 +50,86 @@ def get_reactions_for_user(user_id: int, session: sessionmaker) -> list[str]:
         ).all()
 
         return [row[0].emoji for row in results]
+    
+def get_emoji_delay(session: sessionmaker) -> int:
+    """
+    Get Robomoji delay time 
+
+    Returns:
+        int: Delay time in seconds for Robomojis
+    """
+    with session() as sess:
+        result = sess.query(EmojiReactionDelay).first()
+
+        if result is None:
+            sess.execute(insert(EmojiReactionDelay).values(delay_in_seconds=15)) # Fallback default value of 15 seconds
+            return 15
+        
+        return result.delay_in_seconds
+
+def set_emoji_delay(delay_time: int, session: sessionmaker) -> int:
+    """
+    Set Robomoji delay time 
+
+    Args:
+        delay_time (int): Delay time in seconds for Robomojis
+    """
+    with session() as sess:
+        result = sess.query(EmojiReactionDelay).first()
+
+        if result is None:
+            sess.execute(insert(EmojiReactionDelay).values(delay_in_seconds=delay_time))
+            return delay_time
+
+        existing_row: EmojiReactionDelay = result
+        sess.execute(
+            update(EmojiReactionDelay)
+            .where(EmojiReactionDelay.id == existing_row.id)
+            .values(delay_in_seconds=delay_time)
+        )
+        return delay_time
+    
+def get_emoji_last_used(user_id: int, session: sessionmaker) -> datetime:
+    """
+    Get DateTime of last Robomoji reaction
+
+    Args:
+        user_id (int): Discord User ID to add reaction to
+
+    Returns:
+        DateTime: DateTime of last Robomoji reaction for given user
+    """
+    with session() as sess:
+        result = sess.execute(
+            select(EmojiReactionTimes).where(EmojiReactionTimes.user_id == user_id)
+        ).first()
+
+        if result is None:
+            sess.execute(insert(EmojiReactionTimes).values(user_id=user_id, last_reacted=datetime.now())) # First usage of Robomoji in new system by given user
+            return datetime.now() - timedelta(minutes=5)
+        
+        emoji_reaction_time: EmojiReactionTimes = result[0]
+        return emoji_reaction_time.last_reacted
+
+def set_emoji_last_used(user_id: int, last_used: DateTime, session: sessionmaker):
+    """
+    Set DateTime of last Robomoji reaction
+
+    Args:
+        user_id (int): Discord User ID to add reaction to
+        last_used (DateTime):  DateTime of most recently used Robomoji reaction
+    """
+    with session() as sess:
+        result = sess.execute(
+            select(EmojiReactionTimes).where(EmojiReactionTimes.user_id == user_id)
+        ).first()
+
+        if result is None:
+            sess.execute(insert(EmojiReactionTimes).values(user_id=user_id, last_reacted=last_used)) # Extra check just in case row somehow doesn't exist
+
+        existing_row: EmojiReactionTimes = result[0]
+        sess.execute(
+            update(EmojiReactionTimes)
+            .where(EmojiReactionTimes.id == existing_row.id)
+            .values(user_id=user_id, last_reacted=last_used)
+        )

--- a/db/emoji_reactions.py
+++ b/db/emoji_reactions.py
@@ -51,7 +51,7 @@ def get_reactions_for_user(user_id: int, session: sessionmaker) -> list[str]:
 
         return [row[0].emoji for row in results]
     
-def get_emoji_delay(session: sessionmaker) -> int:
+def get_emoji_reaction_delay(session: sessionmaker) -> int:
     """
     Get Robomoji delay time 
 
@@ -67,7 +67,7 @@ def get_emoji_delay(session: sessionmaker) -> int:
         
         return result.delay_in_seconds
 
-def set_emoji_delay(delay_time: int, session: sessionmaker) -> int:
+def set_emoji_reaction_delay(delay_time: int, session: sessionmaker) -> int:
     """
     Set Robomoji delay time 
 
@@ -89,7 +89,7 @@ def set_emoji_delay(delay_time: int, session: sessionmaker) -> int:
         )
         return delay_time
     
-def get_emoji_last_used(user_id: int, session: sessionmaker) -> datetime:
+def get_emoji_reaction_last_used(user_id: int, session: sessionmaker) -> datetime:
     """
     Get DateTime of last Robomoji reaction
 
@@ -111,7 +111,7 @@ def get_emoji_last_used(user_id: int, session: sessionmaker) -> datetime:
         emoji_reaction_time: EmojiReactionTimes = result[0]
         return emoji_reaction_time.last_reacted
 
-def set_emoji_last_used(user_id: int, last_used: DateTime, session: sessionmaker):
+def set_emoji_reaction_last_used(user_id: int, last_used: DateTime, session: sessionmaker):
     """
     Set DateTime of last Robomoji reaction
 

--- a/db/emoji_reactions.py
+++ b/db/emoji_reactions.py
@@ -7,6 +7,8 @@ from db.models import EmojiReactions, EmojiReactionDelay, EmojiReactionTimes
 
 LOG = logging.getLogger(__name__)
 
+DEFAULT_EMOJI_REACTION_DELAY = 15 # Default delay for Robomoji reactions
+
 
 def toggle_emoji_reaction(user_id: int, emoji: str, session: sessionmaker) -> bool:
     """Toggles emoji reaction for a given user
@@ -62,8 +64,8 @@ def get_emoji_reaction_delay(session: sessionmaker) -> int:
         result = sess.query(EmojiReactionDelay).first()
 
         if result is None:
-            sess.execute(insert(EmojiReactionDelay).values(delay_in_seconds=15)) # Fallback default value of 15 seconds
-            return 15
+            sess.execute(insert(EmojiReactionDelay).values(delay_in_seconds=DEFAULT_EMOJI_REACTION_DELAY)) # Fallback default value of 15 seconds
+            return DEFAULT_EMOJI_REACTION_DELAY
         
         return result.delay_in_seconds
 

--- a/db/models.py
+++ b/db/models.py
@@ -230,6 +230,28 @@ class EmojiReactions(Base):
             f"EmojiReaction(id={self.id!r}, user_id={self.user_id!r},"
             f" emoji={self.emoji})"
         )
+    
+class EmojiReactionDelay(Base):
+    __tablename__ = "emoji_reaction_delay"
+
+    id = Column(Integer, primary_key=True)
+    delay_in_seconds = Column(Integer, nullable=False)
+
+    def __repr__(self):
+        return f"EmojiReactionDelay(id={self.id!r}, delay_in_seconds={self.delay_in_seconds!r})"
+    
+class EmojiReactionTimes(Base):
+    __tablename__ = "emoji_reaction_times"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(BigInteger, nullable=False)
+    last_reacted = Column(DateTime, nullable=False)
+
+    def __repr__(self):
+        return (
+            f"EmojiReactionTimes(id={self.id!r}, user_id={self.user_id!r},"
+            f" last_reacted={self.last_reacted!r})"
+        )
 
 
 class TempRoles(Base):


### PR DESCRIPTION
Made in reference to issue #90 

Adds the /reactions set_emoji_reaction_delay {int} command.

This allows mods to set a timed delay in seconds for Robomoji reactions. Defaults to a delay of 15 seconds between reactions if not set. Records current datetime when Robonana reacts to a user's message and prevents further reactions until the delay has passed.