### PR TITLE
Add role to user on /temprole extend

### DIFF
--- a/controllers/temprole_controller.py
+++ b/controllers/temprole_controller.py
@@ -81,6 +81,18 @@ class TempRoleController:
         if temprole is None:
             expiration += extension_duration
             DB().set_temprole(user_id, role.id, interaction.guild_id, expiration)
+            # Add role to user
+            try:
+                await member.add_roles(role)
+            except:
+                temprole = DB().retrieve_temprole(user_id, role.id)
+                if temprole is not None:
+                    DB().delete_temprole(temprole.id)
+                return await interaction.response.send_message(
+                    f"Failed to assign {role.name} to {user.mention}. Ensure this role is"
+                    " not above RoboBanana.",
+                    ephemeral=True,
+                )
         else:
             expiration = temprole.expiration + extension_duration
             DB().set_temprole(user_id, role.id, interaction.guild_id, expiration)


### PR DESCRIPTION
Currently if the user does not have a given role and `/temprole extend` is used, it assigns the temprole expiration in the database, but does not actually give the user the role. This fixes this bug so that `/temprole extend` can be used to give roles without needing to first use `/temprole add`