### PR TITLE
Don't show ephemeral messages in overlay

### DIFF
--- a/server/util/discord_client.py
+++ b/server/util/discord_client.py
@@ -35,6 +35,8 @@ class ServerBot(Client):
             reference_author = await self.find_reference_author(message)
             if not should_send:
                 return
+            if message.flags.ephemeral:
+                return
             modified_message_content = reference_author + message.content
 
             roles = []


### PR DESCRIPTION
Small PR that fixes the bug where ephemeral messages are published to the chat overlay