### PR TITLE
Convert the GM reward method to use temproles

### DIFF
--- a/controllers/good_morning_controller.py
+++ b/controllers/good_morning_controller.py
@@ -94,7 +94,7 @@ class GoodMorningController:
 
         current_time = datetime.now(tz = PACIFIC_TZ)
         day_delta = 6 - current_time.weekday()
-        if day_delta is 0: # If it is currently sunday, manually add 7 days since we want the upcoming sunday, not the current one
+        if day_delta == 0: # If it is currently sunday, manually add 7 days since we want the upcoming sunday, not the current one
             day_delta = 7
         upcoming_sunday = current_time + timedelta(days = day_delta)
         upcoming_sunday = upcoming_sunday.replace(hour=GM_TEMPROLE_TIME.hour, minute=GM_TEMPROLE_TIME.minute)
@@ -102,7 +102,7 @@ class GoodMorningController:
 
         # Assign roles
         for idx, user_id in enumerate(rewarded_user_ids):
-            await TempRoleController.set_role(str(user_id), reward_role, str(temprole_duration))
+            await TempRoleController.set_role(str(user_id), reward_role, str(temprole_duration)+"m")
 
             num_rewarded = idx + 1
             if (num_rewarded / reward_count) > progress_threshold:

--- a/controllers/good_morning_controller.py
+++ b/controllers/good_morning_controller.py
@@ -102,7 +102,7 @@ class GoodMorningController:
 
         # Assign roles
         for idx, user_id in enumerate(rewarded_user_ids):
-            await TempRoleController.set_role(str(user_id), reward_role, str(temprole_duration)+"m")
+            await TempRoleController.set_role(user_id, reward_role, str(temprole_duration)+"m")
 
             num_rewarded = idx + 1
             if (num_rewarded / reward_count) > progress_threshold:

--- a/controllers/temprole_controller.py
+++ b/controllers/temprole_controller.py
@@ -23,8 +23,8 @@ class TempRoleController:
         self.client = client
 
     @staticmethod
-    async def set_role(user: User | str, role: Role, duration: str) -> tuple[bool, str]:
-        if isinstance(user, User):
+    async def set_role(user: User | int, role: Role, duration: str) -> tuple[bool, str]:
+        if hasattr(user, "id"):
             user_id = user.id
         else:
             user_id = user
@@ -50,7 +50,7 @@ class TempRoleController:
                 return (
                     False,
                     (
-                        f"Failed to assign {role.name} to {user.mention}. Ensure this"
+                        f"Failed to assign {role.name} to {member.mention}. Ensure this"
                         " role is not above RoboBanana."
                     ),
                 )
@@ -58,7 +58,7 @@ class TempRoleController:
         unixtime = time.mktime(expiration.timetuple())
         return (
             True,
-            f"Assigned {role.mention} to {user.mention} expiring <t:{unixtime:.0f}:f>",
+            f"Assigned {role.mention} to {member.mention} expiring <t:{unixtime:.0f}:f>",
         )
 
     @staticmethod

--- a/controllers/temprole_controller.py
+++ b/controllers/temprole_controller.py
@@ -23,8 +23,11 @@ class TempRoleController:
         self.client = client
 
     @staticmethod
-    async def set_role(user: User, role: Role, duration: str) -> tuple[bool, str]:
-        user_id = user.id
+    async def set_role(user: User | str, role: Role, duration: str) -> tuple[bool, str]:
+        if isinstance(user, User):
+            user_id = user.id
+        else:
+            user_id = user
         delta = timedelta(seconds=timeparse(duration))
         expiration = datetime.now() + delta
         guild = role.guild


### PR DESCRIPTION
Closes #101 
This implementation would also allow #102 (and the current implementation) to seamlessly carry roles into the new week.
If the roles expire at 11pm but new temproles are distributed at for example 10pm, only people who didn't get a new temprole would lose theirs. 
For this to work with the current accrual times, the roles should probably last till 11:59pm and be distributed at 11:05pm or something like that though. That is a simple change thankfully.

**This PR is now extended by #108 - please read that PRs comment. GitHub does not support dependent PRs unfortunately.**