### PR TITLE
Implement automatic assignment of the GM role every sunday

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -27,6 +27,7 @@ from config import YAMLConfig as Config
 from controllers.reaction_controller import ReactionController
 from controllers.sub_controller import SubController
 from controllers.temprole_controller import TempRoleController
+from controllers.good_morning_controller import GoodMorningController
 from db import DB
 from threading import Thread
 from util.discord_utils import DiscordUtils
@@ -79,6 +80,7 @@ class RaffleBot(Client):
         # Leaving here for posterity
         # SubController(self).sync_channel_perms.start()
         TempRoleController(self).expire_roles.start()
+        GoodMorningController(self).auto_reward_users.start()
 
     async def on_message_edit(self, before: Message, message: Message):
         # Don't respond to ourselves

--- a/controllers/good_morning_controller.py
+++ b/controllers/good_morning_controller.py
@@ -94,7 +94,7 @@ class GoodMorningController:
 
         current_time = datetime.now(tz = PACIFIC_TZ)
         day_delta = 6 - current_time.weekday()
-        if day_delta is 0: # If it is currently sunday, manually add 7 days since we want the upcoming sunday, not the current one
+        if day_delta == 0: # If it is currently sunday, manually add 7 days since we want the upcoming sunday, not the current one
             day_delta = 7
         upcoming_sunday = current_time + timedelta(days = day_delta)
         upcoming_sunday = upcoming_sunday.replace(hour=GM_TEMPROLE_TIME.hour, minute=GM_TEMPROLE_TIME.minute)
@@ -102,7 +102,7 @@ class GoodMorningController:
 
         # Assign roles
         for idx, user_id in enumerate(rewarded_user_ids):
-            await TempRoleController.set_role(str(user_id), reward_role, str(temprole_duration))
+            await TempRoleController.set_role(str(user_id), reward_role, str(temprole_duration)+"m")
 
             num_rewarded = idx + 1
             if (num_rewarded / reward_count) > progress_threshold:

--- a/controllers/good_morning_controller.py
+++ b/controllers/good_morning_controller.py
@@ -1,4 +1,4 @@
-from discord import Interaction, Thread
+from discord import Client, Interaction, Thread
 from db import DB
 from config import YAMLConfig as Config
 from datetime import datetime, timedelta
@@ -6,23 +6,33 @@ from time import mktime as epochtime
 from pytz import timezone
 import asyncio
 from controllers.temprole_controller import TempRoleController
+import logging
+from discord.ext import tasks
 
+LOG = logging.getLogger(__name__)
 
 STREAM_CHAT_ID = Config.CONFIG["Discord"]["Channels"]["Stream"]
 REWARD_ROLE_ID = Config.CONFIG["Discord"]["GoodMorning"]["RewardRole"]
 REWARD_REDEMPTION_CHANNEL_ID = Config.CONFIG["Discord"]["GoodMorning"][
     "RedemptionChannel"
 ]
+REWARD_PROGRESS_CHANNEL = Config.CONFIG["Discord"]["GoodMorning"]["ProgressChannel"]
 GOOD_MORNING_EXPLANATION = "What's this message? <#1064317660084584619>"
 
 PACIFIC_TZ = timezone("US/Pacific")
 UTC_TZ = timezone("UTC")
 START_TIME = PACIFIC_TZ.localize(datetime.utcnow().replace(hour=9, minute=0)).time()
 END_TIME = PACIFIC_TZ.localize(datetime.utcnow().replace(hour=14, minute=0)).time()
-GM_TEMPROLE_TIME = PACIFIC_TZ.localize(datetime.utcnow().replace(hour=23, minute=0)).time()
+# The time on the upcoming sunday the temporary GM role will expire. Setting this AFTER the automatic distribution time ensures a seamless role transition.
+GM_TEMPROLE_TARGET_TIME = PACIFIC_TZ.localize(datetime.utcnow().replace(hour=23, minute=30, second=0, microsecond=0)).time()
+# The time each day we run the `auto_reward_users` method. The method itself checks if it's sunday as that seems to be the easiest way to only do this on sundays.
+GM_TEMPROLE_AUTO_TIME = PACIFIC_TZ.localize(datetime.utcnow().replace(hour=23, minute=00, second=0, microsecond=0)).time()
 
 
 class GoodMorningController:
+    def __init__(self, client: Client):
+        self.client = client
+        
     async def get_morning_points(interaction: Interaction):
         points = DB().get_morning_points(interaction.user.id)
         await interaction.response.send_message(
@@ -86,6 +96,49 @@ class GoodMorningController:
             name="Good Morning Reward Progress"
         )
 
+        await GoodMorningController.tempreward_upcoming_sunday(thread, rewarded_user_ids, reward_role)
+
+        reward_message = (
+            f"Congrats {reward_role.mention}!"
+            f" Head over to <#{REWARD_REDEMPTION_CHANNEL_ID}> to redeem your reward!"
+        )
+        await interaction.followup.send(reward_message)
+
+    @tasks.loop(time=GM_TEMPROLE_AUTO_TIME)
+    async def auto_reward_users(self):
+        current_weekday = datetime.now(tz=PACIFIC_TZ).weekday()
+        if current_weekday != 6:
+            # fail silently as it is not sunday
+            return
+        
+        LOG.info("[AUTO GM TASK] Running automatic GM reward distribution...")
+        
+        rewarded_user_ids = DB().get_morning_reward_winners()
+        if len(rewarded_user_ids) == 0:
+            LOG.info("[AUTO GM TASK] No users to reward")
+            return
+
+        guild = self.client.get_guild(Config.CONFIG["Discord"]["GuildID"])
+        reward_role = guild.get_role(REWARD_ROLE_ID)
+        progres_channel = guild.get_channel(REWARD_PROGRESS_CHANNEL)
+
+        original_message = await progres_channel.send("Good Morning Reward Progress")
+        thread: Thread = await original_message.create_thread(
+            name="Good Morning Reward Progress",
+        )
+
+        await self.tempreward_upcoming_sunday(thread, rewarded_user_ids, reward_role)
+
+        DB().reset_all_morning_points()
+
+        reward_message = (
+            f"Congrats {reward_role.mention}!"
+            f" Head over to <#{REWARD_REDEMPTION_CHANNEL_ID}> to redeem your reward!"
+        )
+        await progres_channel.send(reward_message)
+
+    @staticmethod
+    async def tempreward_upcoming_sunday(thread, rewarded_user_ids, reward_role):
         reward_count = len(rewarded_user_ids)
 
         await thread.send(f"Distributing good morning rewards to {reward_count} users.")
@@ -97,7 +150,7 @@ class GoodMorningController:
         if day_delta == 0: # If it is currently sunday, manually add 7 days since we want the upcoming sunday, not the current one
             day_delta = 7
         upcoming_sunday = current_time + timedelta(days = day_delta)
-        upcoming_sunday = upcoming_sunday.replace(hour=GM_TEMPROLE_TIME.hour, minute=GM_TEMPROLE_TIME.minute)
+        upcoming_sunday = upcoming_sunday.replace(hour=GM_TEMPROLE_TARGET_TIME.hour, minute=GM_TEMPROLE_TARGET_TIME.minute)
         temprole_duration = int((upcoming_sunday - current_time) / timedelta(minutes=1)) # Convert to how many minutes are in this delta, then to int to drop any decimals eventhough there shouldn't be any
 
         # Assign roles
@@ -111,12 +164,6 @@ class GoodMorningController:
 
             # Rate limit
             await asyncio.sleep(1)
-
-        reward_message = (
-            f"Congrats {reward_role.mention}!"
-            f" Head over to <#{REWARD_REDEMPTION_CHANNEL_ID}> to redeem your reward!"
-        )
-        await interaction.followup.send(reward_message)
 
     async def reset_all_morning_points(interaction: Interaction):
         DB().reset_all_morning_points()

--- a/controllers/good_morning_controller.py
+++ b/controllers/good_morning_controller.py
@@ -102,7 +102,7 @@ class GoodMorningController:
 
         # Assign roles
         for idx, user_id in enumerate(rewarded_user_ids):
-            await TempRoleController.set_role(str(user_id), reward_role, str(temprole_duration)+"m")
+            await TempRoleController.set_role(user_id, reward_role, str(temprole_duration)+"m")
 
             num_rewarded = idx + 1
             if (num_rewarded / reward_count) > progress_threshold:

--- a/controllers/temprole_controller.py
+++ b/controllers/temprole_controller.py
@@ -23,8 +23,8 @@ class TempRoleController:
         self.client = client
 
     @staticmethod
-    async def set_role(user: User | str, role: Role, duration: str) -> tuple[bool, str]:
-        if isinstance(user, User):
+    async def set_role(user: User | int, role: Role, duration: str) -> tuple[bool, str]:
+        if hasattr(user, "id"):
             user_id = user.id
         else:
             user_id = user
@@ -50,7 +50,7 @@ class TempRoleController:
                 return (
                     False,
                     (
-                        f"Failed to assign {role.name} to {user.mention}. Ensure this"
+                        f"Failed to assign {role.name} to {member.mention}. Ensure this"
                         " role is not above RoboBanana."
                     ),
                 )
@@ -58,7 +58,7 @@ class TempRoleController:
         unixtime = time.mktime(expiration.timetuple())
         return (
             True,
-            f"Assigned {role.mention} to {user.mention} expiring <t:{unixtime:.0f}:f>",
+            f"Assigned {role.mention} to {member.mention} expiring <t:{unixtime:.0f}:f>",
         )
 
     @staticmethod

--- a/controllers/temprole_controller.py
+++ b/controllers/temprole_controller.py
@@ -23,8 +23,11 @@ class TempRoleController:
         self.client = client
 
     @staticmethod
-    async def set_role(user: User, role: Role, duration: str) -> tuple[bool, str]:
-        user_id = user.id
+    async def set_role(user: User | str, role: Role, duration: str) -> tuple[bool, str]:
+        if isinstance(user, User):
+            user_id = user.id
+        else:
+            user_id = user
         delta = timedelta(seconds=timeparse(duration))
         expiration = datetime.now() + delta
         guild = role.guild


### PR DESCRIPTION
Closes #101 
Closes #102 

This PR adds a new config option for the channel in which the progress thread should be posted in.
Previously, this was the channel the command was executed in but without a command there is no inherent channel.

It also adds 2 new TIME variables with which to set when the role should expire and when the automatic distribution should take place.
With the current settings, roles are distributed at 11pm with an expiry of "upcoming sunday 11:30pm", making it so roles carry over seamlessly if the user achieved another GM reward. If not, the role simply expires at 11:30pm as it was planned.
The set_role method overrides any active temproles of the same role id, so this works without changes to said method.

Please excuse any code that doesn't follow Python conventions or similar, I'm not a super experienced Python dev.