### PR TITLE
Add an optional arg to predictions to change Nicknames to reflect choice

### DIFF
--- a/commands/mod_commands.py
+++ b/commands/mod_commands.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from typing import Optional
 from discord import app_commands, Interaction, Client, User, TextChannel
 from discord.app_commands.errors import AppCommandError, CheckFailure
 from controllers.good_morning_controller import (
@@ -281,13 +282,14 @@ class ModCommands(app_commands.Group, name="mod"):
 
     @app_commands.command(name="start_prediction")
     @app_commands.checks.has_role("Mod")
-    async def start_prediction(self, interaction: Interaction):
+    @app_commands.describe(set_nickname="Whether to prepend users names with their choice")
+    async def start_prediction(self, interaction: Interaction, set_nickname: Optional[bool] = False):
         """Start new prediction"""
         if DB().has_ongoing_prediction(interaction.guild_id):
             return await interaction.response.send_message(
                 "There is already an ongoing prediction!", ephemeral=True
             )
-        await interaction.response.send_modal(CreatePredictionModal(self.client))
+        await interaction.response.send_modal(CreatePredictionModal(self.client, set_nickname))
 
     @app_commands.command(name="refund_prediction")
     @app_commands.checks.has_role("Mod")

--- a/controllers/predictions/create_prediction_controller.py
+++ b/controllers/predictions/create_prediction_controller.py
@@ -35,6 +35,7 @@ class CreatePredictionController:
         option_one: str,
         option_two: str,
         duration: int,
+        set_nickname: bool,
         client: Client,
     ):
         end_time = datetime.now() + timedelta(seconds=duration)
@@ -46,6 +47,7 @@ class CreatePredictionController:
             option_one,
             option_two,
             end_time,
+            set_nickname,
         )
         prediction_id = DB().get_ongoing_prediction_id(guild_id)
         UpdatePredictionController.publish_prediction_summary(prediction_id)

--- a/controllers/predictions/update_prediction_controller.py
+++ b/controllers/predictions/update_prediction_controller.py
@@ -40,6 +40,7 @@ class UpdatePredictionController:
             "optionOnePoints": prediction_summary.option_one_points,
             "optionTwoPoints": prediction_summary.option_two_points,
             "endTime": prediction_summary.end_time.astimezone(timezone.utc).isoformat(),
+            "setNickname": prediction_summary.set_nickname,
             "acceptingEntries": prediction_summary.accepting_entries,
             "ended": prediction_summary.ended,
         }

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -533,6 +533,7 @@ class DB:
         option_one: str,
         option_two: str,
         end_time: datetime,
+        set_nickname: bool,
     ):
         """Create new prediction for users to enter channel points into
 
@@ -552,6 +553,7 @@ class DB:
             option_one,
             option_two,
             end_time,
+            set_nickname,
             self.session,
         )
 

--- a/db/models.py
+++ b/db/models.py
@@ -42,6 +42,7 @@ class PredictionSummary:
         option_one_points: int,
         option_two_points: int,
         end_time: datetime,
+        set_nickname: bool,
         accepting_entries: bool,
         ended: bool,
     ):
@@ -51,6 +52,7 @@ class PredictionSummary:
         self.option_one_points = option_one_points
         self.option_two_points = option_two_points
         self.end_time = end_time
+        self.set_nickname = set_nickname
         self.accepting_entries = accepting_entries
         self.ended = ended
 
@@ -185,6 +187,7 @@ class Prediction(Base):
     description = Column(VARCHAR(100), nullable=False)
     option_one = Column(VARCHAR(100), nullable=False)
     option_two = Column(VARCHAR(100), nullable=False)
+    set_nickname = Column(Boolean, nullable=False, default=False)
     winning_option = Column(SmallInteger, nullable=True)
 
     entries = relationship("PredictionEntry", back_populates="prediction")

--- a/db/predictions.py
+++ b/db/predictions.py
@@ -13,6 +13,7 @@ def create_prediction(
     option_one: str,
     option_two: str,
     end_time: datetime,
+    set_nickname: bool,
     session: sessionmaker,
 ) -> None:
     if has_ongoing_prediction(guild_id, session):
@@ -28,6 +29,7 @@ def create_prediction(
                 option_one=option_one,
                 option_two=option_two,
                 end_time=end_time,
+                set_nickname=set_nickname,
             )
         )
 
@@ -249,6 +251,7 @@ def get_prediction_summary(
             option_one_points,
             option_two_points,
             prediction.end_time,
+            prediction.set_nickname,
             prediction.accepting_entries,
             prediction.ended,
         )

--- a/server/controllers/prediction_controller.py
+++ b/server/controllers/prediction_controller.py
@@ -44,6 +44,7 @@ class PredictionController:
             prediction_details.option_one,
             prediction_details.option_two,
             prediction_details.duration,
+            False,
             client,
         )
         return True

--- a/views/predictions/create_predictions_modal.py
+++ b/views/predictions/create_predictions_modal.py
@@ -1,14 +1,17 @@
 from discord import ChannelType, TextStyle, Interaction, Client
 from discord.ui import Modal, TextInput
 from datetime import datetime, timedelta
+from typing import Optional
+import logging
 
 from controllers.predictions.create_prediction_controller import (
     CreatePredictionController,
 )
 
+LOG = logging.getLogger(__name__)
 
 class CreatePredictionModal(Modal, title="Start new prediction"):
-    def __init__(self, client: Client):
+    def __init__(self, client: Client, set_nickname=False):
         super().__init__(timeout=None)
         self.client = client
         self.description = TextInput(
@@ -33,6 +36,7 @@ class CreatePredictionModal(Modal, title="Start new prediction"):
             required=True,
             min_length=1,
         )
+        self.set_nickname=set_nickname
 
         self.add_item(self.description)
         self.add_item(self.option_one)
@@ -63,5 +67,6 @@ class CreatePredictionModal(Modal, title="Start new prediction"):
             self.option_one.value,
             self.option_two.value,
             duration,
+            self.set_nickname,
             self.client,
         )


### PR DESCRIPTION
This Commit requires the DB to be migrated (regenerating the docker db volume is fine for testing too)
Added an optional "set_nickname" bool argument to the "start_prediction" command, defaulting to False.
When betting on a prediction, if "set_nickname" is true we prepend the users Username with the name of the choice they picked.

**It is recommended to upgrade to d.py 2.3.2+ with this commit, as we otherwise don't know of the existence of global Display Names and might set weird nicknames ("TAG username" instead of "TAG Display Name") (Doing this should also "fix" usernames being displayed on-stream rather then global Display Names). 
d.py 2.3.2 worked fine for my limited testing here and 2.1.0-->2.3.2 removed no features, so we should be fine.**