### PR TITLE
Add config options missing from the example file

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -27,7 +27,13 @@ Discord:
     NAOpenChannel:
   Predictions:
     Channel:
+  PointsHistory:
+    MaximumTransactions: 5
+  Roles:
+    Bot: 
+    Mod: 
   Subscribers:
+    12MonthTier3Role:
     6MonthTier3Role:
     GiftedTier1Role:
     GiftedTier2Role:


### PR DESCRIPTION
These options aren't in the example file, however they do crash the bot when you try to start it.