### PR TITLE
Implement nickname resets after predictions have been paid out or been refunded

### DIFF
--- a/views/predictions/prediction_vote_modal.py
+++ b/views/predictions/prediction_vote_modal.py
@@ -39,6 +39,8 @@ class PredictionVoteModal(Modal, title="Cast your vote!"):
                 "Invalid point value", ephemeral=True
             )
             return
+        
+        await interaction.response.defer(ephemeral=True, thinking=True)
 
         await PredictionEntryController.create_prediction_entry(
             channel_points, self.guess, interaction, self.client
@@ -52,6 +54,6 @@ class PredictionVoteModal(Modal, title="Cast your vote!"):
         )
         await prediction_message.edit(embed=self.parent)
 
-        await interaction.response.send_message(
+        await interaction.followup.send(
             f"Vote cast with {channel_points} points!", ephemeral=True
         )


### PR DESCRIPTION
This PR implements logic to statelessly revert a users nickname if they have bet in the prediction.
This happens whenever the prediction is paid out or refunded.

I also changed the original modal interaction to be deferred at the beginning of the method - this makes it so a "Robonana is thinking..." will appear in chat while we process our logic - we later edit this message with a followup.
Why do we do this? Discord grants us a maximum of 3 seconds to reply to an interaction and bets can and do exceed this limit.
Deferring increases the time we get to 15 seconds, which is why we do it here.