### PR TITLE
Communal gambling

### DIFF
--- a/commands/mod_commands.py
+++ b/commands/mod_commands.py
@@ -37,6 +37,7 @@ TIER1_ROLE = Config.CONFIG["Discord"]["Subscribers"]["Tier1Role"]
 TIER2_ROLE = Config.CONFIG["Discord"]["Subscribers"]["Tier2Role"]
 TIER3_ROLE = Config.CONFIG["Discord"]["Subscribers"]["Tier3Role"]
 TIER3_ROLE_12MO = Config.CONFIG["Discord"]["Subscribers"]["12MonthTier3Role"]
+CHAT_MOD_ROLE = Config.CONFIG["Discord"]["Roles"]["CMChatModerator"]
 BOT_ROLE = Config.CONFIG["Discord"]["Roles"]["Bot"]
 GIFTED_TIER1_ROLE = Config.CONFIG["Discord"]["Subscribers"]["GiftedTier1Role"]
 GIFTED_TIER2_ROLE = Config.CONFIG["Discord"]["Subscribers"]["GiftedTier3Role"]
@@ -282,7 +283,7 @@ class ModCommands(app_commands.Group, name="mod"):
         )
 
     @app_commands.command(name="start_prediction")
-    @app_commands.checks.has_any_role(TIER3_ROLE_12MO, MOD_ROLE)
+    @app_commands.checks.has_any_role(TIER3_ROLE_12MO, MOD_ROLE, CHAT_MOD_ROLE)
     @app_commands.describe(
         set_nickname="Whether to prepend users names with their choice"
     )

--- a/commands/mod_commands.py
+++ b/commands/mod_commands.py
@@ -36,6 +36,7 @@ POINTS_AUDIT_CHANNEL = Config.CONFIG["Discord"]["ChannelPoints"]["PointsAuditCha
 TIER1_ROLE = Config.CONFIG["Discord"]["Subscribers"]["Tier1Role"]
 TIER2_ROLE = Config.CONFIG["Discord"]["Subscribers"]["Tier2Role"]
 TIER3_ROLE = Config.CONFIG["Discord"]["Subscribers"]["Tier3Role"]
+TIER3_12MONTH_ROLE = Config.CONFIG["Discord"]["Subscribers"]["12MonthTier3Role"]
 BOT_ROLE = Config.CONFIG["Discord"]["Roles"]["Bot"]
 GIFTED_TIER1_ROLE = Config.CONFIG["Discord"]["Subscribers"]["GiftedTier1Role"]
 GIFTED_TIER2_ROLE = Config.CONFIG["Discord"]["Subscribers"]["GiftedTier3Role"]
@@ -281,7 +282,7 @@ class ModCommands(app_commands.Group, name="mod"):
         )
 
     @app_commands.command(name="start_prediction")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_any_role(TIER3_12MONTH_ROLE, "Mod")
     @app_commands.describe(
         set_nickname="Whether to prepend users names with their choice"
     )

--- a/commands/mod_commands.py
+++ b/commands/mod_commands.py
@@ -36,7 +36,6 @@ POINTS_AUDIT_CHANNEL = Config.CONFIG["Discord"]["ChannelPoints"]["PointsAuditCha
 TIER1_ROLE = Config.CONFIG["Discord"]["Subscribers"]["Tier1Role"]
 TIER2_ROLE = Config.CONFIG["Discord"]["Subscribers"]["Tier2Role"]
 TIER3_ROLE = Config.CONFIG["Discord"]["Subscribers"]["Tier3Role"]
-TIER3_12MONTH_ROLE = Config.CONFIG["Discord"]["Subscribers"]["12MonthTier3Role"]
 BOT_ROLE = Config.CONFIG["Discord"]["Roles"]["Bot"]
 GIFTED_TIER1_ROLE = Config.CONFIG["Discord"]["Subscribers"]["GiftedTier1Role"]
 GIFTED_TIER2_ROLE = Config.CONFIG["Discord"]["Subscribers"]["GiftedTier3Role"]
@@ -282,7 +281,7 @@ class ModCommands(app_commands.Group, name="mod"):
         )
 
     @app_commands.command(name="start_prediction")
-    @app_commands.checks.has_any_role(TIER3_12MONTH_ROLE, "Mod")
+    @app_commands.checks.has_any_role("THE ONES WHO KNOW A LOT (12 Month T3)", "Mod")
     @app_commands.describe(
         set_nickname="Whether to prepend users names with their choice"
     )

--- a/commands/mod_commands.py
+++ b/commands/mod_commands.py
@@ -304,7 +304,7 @@ class ModCommands(app_commands.Group, name="mod"):
         await PayoutPredictionController.refund_prediction(interaction, self.client)
 
     @app_commands.command(name="close_prediction")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_any_role("THE ONES WHO KNOW A LOT (12 Month T3)", "Mod")
     async def close_prediction(self, interaction: Interaction):
         """CLOSE PREDICTION"""
         await ClosePredictionController.close_prediction(interaction.guild_id)

--- a/commands/mod_commands.py
+++ b/commands/mod_commands.py
@@ -36,6 +36,7 @@ POINTS_AUDIT_CHANNEL = Config.CONFIG["Discord"]["ChannelPoints"]["PointsAuditCha
 TIER1_ROLE = Config.CONFIG["Discord"]["Subscribers"]["Tier1Role"]
 TIER2_ROLE = Config.CONFIG["Discord"]["Subscribers"]["Tier2Role"]
 TIER3_ROLE = Config.CONFIG["Discord"]["Subscribers"]["Tier3Role"]
+TIER3_ROLE_12MO = Config.CONFIG["Discord"]["Subscribers"]["12MonthTier3Role"]
 BOT_ROLE = Config.CONFIG["Discord"]["Roles"]["Bot"]
 GIFTED_TIER1_ROLE = Config.CONFIG["Discord"]["Subscribers"]["GiftedTier1Role"]
 GIFTED_TIER2_ROLE = Config.CONFIG["Discord"]["Subscribers"]["GiftedTier3Role"]
@@ -281,7 +282,7 @@ class ModCommands(app_commands.Group, name="mod"):
         )
 
     @app_commands.command(name="start_prediction")
-    @app_commands.checks.has_any_role("THE ONES WHO KNOW A LOT (12 Month T3)", "Mod")
+    @app_commands.checks.has_any_role(TIER3_ROLE_12MO, MOD_ROLE)
     @app_commands.describe(
         set_nickname="Whether to prepend users names with their choice"
     )
@@ -304,7 +305,7 @@ class ModCommands(app_commands.Group, name="mod"):
         await PayoutPredictionController.refund_prediction(interaction, self.client)
 
     @app_commands.command(name="close_prediction")
-    @app_commands.checks.has_any_role("THE ONES WHO KNOW A LOT (12 Month T3)", "Mod")
+    @app_commands.checks.has_any_role(TIER3_ROLE_12MO, MOD_ROLE)
     async def close_prediction(self, interaction: Interaction):
         """CLOSE PREDICTION"""
         await ClosePredictionController.close_prediction(interaction.guild_id)


### PR DESCRIPTION
This PR enables 12 month tier 3 subscribers to start predictions in addition to the moderator ability to do so.

Line 284 of mod_commands.py can be altered to include 6moT3's/community managers by adding their role name to the list as well with no other changes.
This does allow the long term subs to flag the set nickname, which could be a pain.

Paying out and refunding predictions are still Mod exclusive.