### PR TITLE
Stop using magic strings for command permission checks (+ small bugfix)

### DIFF
--- a/commands/connect_four.py
+++ b/commands/connect_four.py
@@ -11,6 +11,7 @@ from util.server_utils import get_base_url
 
 PUBLISH_CONNECT_FOUR_URL = f"{get_base_url()}/publish-connect-four"
 AUTH_TOKEN = Config.CONFIG["Secrets"]["Server"]["Token"]
+MOD_ROLE = Config.CONFIG["Discord"]["Roles"]["Mod"]
 
 LOG = logging.getLogger(__name__)
 
@@ -26,7 +27,7 @@ class ConnectFourCommands(app_commands.Group, name="connect_four"):
         self.controller = ConnectFourController()
 
     @app_commands.command()
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     async def enable(self, interaction: Interaction):
         """Allow users to challenge each other to Connect Four"""
         self.enabled = True
@@ -37,7 +38,7 @@ class ConnectFourCommands(app_commands.Group, name="connect_four"):
         await interaction.response.send_message("Connect Four Enabled!", ephemeral=True)
 
     @app_commands.command()
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     async def disable(self, interaction: Interaction):
         """Prevent users from challenging each other to Connect Four"""
         self.enabled = False

--- a/commands/manager_commands.py
+++ b/commands/manager_commands.py
@@ -24,6 +24,9 @@ APPROVED_TAG = Config.CONFIG["Discord"]["VODReview"]["ApprovedTag"]
 REJECTED_TAG = Config.CONFIG["Discord"]["VODReview"]["RejectedTag"]
 APPROVED_ROLE = Config.CONFIG["Discord"]["VODReview"]["ApprovedRole"]
 REJECTED_ROLE = Config.CONFIG["Discord"]["VODReview"]["RejectedRole"]
+MOD_ROLE = Config.CONFIG["Discord"]["Roles"]["Mod"]
+CM_ROLE = Config.CONFIG["Discord"]["Roles"]["CM"]
+VOD_TEAM_ROLE = Config.CONFIG["Discord"]["VODReview"]["ReviewerRole"]
 USER_ID_PATTERN = re.compile(r"(<@([0-9]+)>)")
 
 LOG = logging.getLogger(__name__)
@@ -57,7 +60,7 @@ class ManagerCommands(app_commands.Group, name="manager"):
         return await super().on_error(interaction, error)
 
     @app_commands.command(name="flag_vod")
-    @app_commands.checks.has_any_role("Mod", "Community Manager", "VOD Review Team")
+    @app_commands.checks.has_any_role(MOD_ROLE, CM_ROLE, VOD_TEAM_ROLE)
     @app_commands.describe(vod_type="VOD Type (Approved/Rejected)")
     @app_commands.describe(duration="Duration to add to temprole")
     async def flag_vod(
@@ -75,7 +78,7 @@ class ManagerCommands(app_commands.Group, name="manager"):
             )
 
     @app_commands.command(name="add_balance")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     @app_commands.describe(user="Community Manager to add VOD Review credit for")
     @app_commands.describe(duration="Amount of time to add to user's balance")
     async def add_balance(self, interaction: Interaction, user: User, duration: str):
@@ -83,20 +86,20 @@ class ManagerCommands(app_commands.Group, name="manager"):
         await VODReviewBankController.add_balance(user, duration, interaction)
 
     @app_commands.command(name="balance")
-    @app_commands.checks.has_any_role("Mod", "Community Manager", "VOD Review Team")
+    @app_commands.checks.has_any_role(MOD_ROLE, CM_ROLE, VOD_TEAM_ROLE)
     async def balance(self, interaction: Interaction) -> None:
         """Check Gifted T3 credit"""
         await VODReviewBankController.get_balance(interaction.user, interaction)
 
     @app_commands.command(name="balance_for")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     @app_commands.describe(user="Community Manager to check VOD Review credit for")
     async def balance_for(self, interaction: Interaction, user: User) -> None:
         """Check Gifted T3 credit for specified user"""
         await VODReviewBankController.get_balance(user, interaction)
 
     @app_commands.command(name="redeem")
-    @app_commands.checks.has_any_role("Mod", "Community Manager", "VOD Review Team")
+    @app_commands.checks.has_any_role(MOD_ROLE, CM_ROLE, VOD_TEAM_ROLE)
     @app_commands.describe(user="Community Manager to check VOD Review credit for")
     @app_commands.describe(
         duration="Duration to redeem T3 for (if balance is sufficient)"
@@ -191,7 +194,7 @@ class ManagerCommands(app_commands.Group, name="manager"):
         await VODReviewBankController.increment_balance(interaction.user, interaction)
 
     @app_commands.command(name="get_review_rounds")
-    @app_commands.checks.has_any_role("Mod", "Community Manager", "VOD Review Team")
+    @app_commands.checks.has_any_role(MOD_ROLE, CM_ROLE, VOD_TEAM_ROLE)
     @app_commands.describe(total_rounds="total number of rounds in VOD")
     async def get_review_rounds(
         self, interaction: Interaction, total_rounds: int

--- a/commands/meme_commands.py
+++ b/commands/meme_commands.py
@@ -1,7 +1,10 @@
 from discord import app_commands, Interaction, Client
 import random
 
+from config import YAMLConfig as Config
+
 HOOJ_DISCORD_ID = 82969926125490176
+MOD_ROLE = Config.CONFIG["Discord"]["Roles"]["Mod"]
 
 
 def get_processed_string(string):
@@ -41,7 +44,7 @@ class MemeCommands(app_commands.Group, name="meme"):
         return interaction.user.id == HOOJ_DISCORD_ID
 
     @app_commands.command(name="generate_chain")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     async def generate_chain(self, interaction: Interaction) -> None:
         if not self.check_hooj(interaction):
             return
@@ -74,7 +77,7 @@ class MemeCommands(app_commands.Group, name="meme"):
         await interaction.response.send_message("Chain generated!", ephemeral=True)
 
     @app_commands.command(name="hooj_message")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     @app_commands.describe(length="length of message")
     async def hooj_message(self, interaction: Interaction, length: int) -> None:
         if not self.check_hooj(interaction):

--- a/commands/mod_commands.py
+++ b/commands/mod_commands.py
@@ -84,7 +84,7 @@ class ModCommands(app_commands.Group, name="mod"):
         return await super().on_error(interaction, error)
 
     @app_commands.command(name="reset_vod_submission")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     @app_commands.describe(user="Discord User to reset vod submission for")
     async def reset_vod_submission(self, interaction: Interaction, user: User) -> None:
         """Allows the given userID to submit a VOD."""
@@ -92,7 +92,7 @@ class ModCommands(app_commands.Group, name="mod"):
         await interaction.response.send_message("Success!", ephemeral=True)
 
     @app_commands.command(name="chess")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     @app_commands.describe(open_value="1 for yes 0 for no")
     @app_commands.describe(na_score="-1 for no change")
     @app_commands.describe(eu_score="-1 for no change")
@@ -112,7 +112,7 @@ class ModCommands(app_commands.Group, name="mod"):
         await interaction.response.send_message("Chess event sent!", ephemeral=True)
 
     @app_commands.command(name="timer")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     @app_commands.describe(time="Time in seconds")
     async def timer(
         self,
@@ -132,7 +132,7 @@ class ModCommands(app_commands.Group, name="mod"):
         await interaction.response.send_message("Timer created!", ephemeral=True)
 
     @app_commands.command(name="poll")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     @app_commands.describe(title="title")
     @app_commands.describe(option_one="option_one")
     @app_commands.describe(option_two="option_two")
@@ -162,7 +162,7 @@ class ModCommands(app_commands.Group, name="mod"):
         await interaction.response.send_message("Poll created!", ephemeral=True)
 
     @app_commands.command(name="gift")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     @app_commands.describe(num_winners="num_winners")
     @app_commands.describe(oprah="Oprah")
     async def gift(self, interaction: Interaction, oprah: str, num_winners: int):
@@ -192,7 +192,7 @@ class ModCommands(app_commands.Group, name="mod"):
             )
 
     @app_commands.command(name="start")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     @app_commands.describe(raffle_type="Raffle Type (default: normal)")
     async def start(
         self, interaction: Interaction, raffle_type: RaffleType = RaffleType.normal
@@ -209,7 +209,7 @@ class ModCommands(app_commands.Group, name="mod"):
         await interaction.response.send_modal(modal)
 
     @app_commands.command(name="end")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     async def end(
         self,
         interaction: Interaction,
@@ -236,14 +236,14 @@ class ModCommands(app_commands.Group, name="mod"):
         DB().close_raffle(interaction.guild.id, end_time=datetime.now())
 
     @app_commands.command(name="add_reward")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     async def add_reward(self, interaction: Interaction):
         """Creates new channel reward for redemption"""
         modal = AddRewardModal()
         await interaction.response.send_modal(modal)
 
     @app_commands.command(name="remove_reward")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     @app_commands.describe(name="Name of reward to remove")
     async def remove_reward(self, interaction: Interaction, name: str):
         """Removes channel reward for redemption"""
@@ -253,7 +253,7 @@ class ModCommands(app_commands.Group, name="mod"):
         )
 
     @app_commands.command(name="allow_redemptions")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     async def allow_redemptions(self, interaction: Interaction):
         """Allow rewards to be redeemed"""
         DB().allow_redemptions()
@@ -262,7 +262,7 @@ class ModCommands(app_commands.Group, name="mod"):
         )
 
     @app_commands.command(name="pause_redemptions")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     async def pause_redemptions(self, interaction: Interaction):
         """Pause rewards from being redeemed"""
         DB().pause_redemptions()
@@ -271,7 +271,7 @@ class ModCommands(app_commands.Group, name="mod"):
         )
 
     @app_commands.command(name="check_redemption_status")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     async def check_redemption_status(self, interaction: Interaction):
         """Check whether or not rewards are eligible to be redeemed"""
         status = DB().check_redemption_status()
@@ -281,7 +281,7 @@ class ModCommands(app_commands.Group, name="mod"):
         )
 
     @app_commands.command(name="start_prediction")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     @app_commands.describe(
         set_nickname="Whether to prepend users names with their choice"
     )
@@ -298,13 +298,13 @@ class ModCommands(app_commands.Group, name="mod"):
         )
 
     @app_commands.command(name="refund_prediction")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     async def refund_prediction(self, interaction: Interaction):
         """Refund ongoing prediction, giving users back the points they wagered"""
         await PayoutPredictionController.refund_prediction(interaction, self.client)
 
     @app_commands.command(name="close_prediction")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     async def close_prediction(self, interaction: Interaction):
         """CLOSE PREDICTION"""
         await ClosePredictionController.close_prediction(interaction.guild_id)
@@ -319,7 +319,7 @@ class ModCommands(app_commands.Group, name="mod"):
         await interaction.response.send_message("Prediction closed!", ephemeral=True)
 
     @app_commands.command(name="payout_prediction")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     @app_commands.describe(option="Option to payout")
     async def payout_prediction(
         self, interaction: Interaction, option: PredictionChoice
@@ -330,14 +330,14 @@ class ModCommands(app_commands.Group, name="mod"):
         )
 
     @app_commands.command(name="redo_payout")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     @app_commands.describe(option="Option to payout")
     async def redo_payout(self, interaction: Interaction, option: PredictionOutcome):
         """Redo the last prediction's payout"""
         await PayoutPredictionController.redo_payout(option, interaction, self.client)
 
     @app_commands.command(name="set_chat_mode")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     @app_commands.describe(mode="Chat Mode")
     @app_commands.describe(channel="Channel")
     async def set_chat_mode(
@@ -470,7 +470,7 @@ class ModCommands(app_commands.Group, name="mod"):
             )
 
     @app_commands.command(name="give_points")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     @app_commands.describe(user="User ID to award points")
     @app_commands.describe(points="Number of points to award")
     @app_commands.describe(reason="Reason for awarding points")
@@ -503,7 +503,7 @@ class ModCommands(app_commands.Group, name="mod"):
         )
 
     @app_commands.command(name="good_morning_count")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     async def good_morning_count(self, interaction: Interaction):
         """Check how many users have said good morning today!"""
         count = DB().get_today_morning_count()
@@ -512,26 +512,26 @@ class ModCommands(app_commands.Group, name="mod"):
         )
 
     @app_commands.command(name="good_morning_reward")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     async def good_morning_reward(self, interaction: Interaction):
         """Reward users who have met the 'Good Morning' threshold"""
         await GoodMorningController.reward_users(interaction)
 
     @app_commands.command(name="good_morning_reset")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     async def good_morning_reset(self, interaction: Interaction):
         """Reset all weekly good morning points to 0"""
         await GoodMorningController.reset_all_morning_points(interaction)
 
     @app_commands.command(name="good_morning_increment")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     @app_commands.describe(points="Number of points to award")
     async def good_morning_increment(self, interaction: Interaction, points: int):
         """Give all users a fixed number of good morning points"""
         await GoodMorningController.good_morning_increment(points, interaction)
 
     @app_commands.command(name="remove_raffle_winner")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     @app_commands.describe(user="User ID to remove win from")
     async def remove_raffle_winner(self, interaction: Interaction, user: User):
         one_week_ago = datetime.now().date() - timedelta(days=6)

--- a/commands/overlay_commands.py
+++ b/commands/overlay_commands.py
@@ -8,12 +8,14 @@ from discord import (
 )
 import logging
 from enum import Enum
+from config import YAMLConfig as Config
 
 from controllers.overlay_controller import OverlayController
 from views.overlay.configure_modal import OverlayConfigurationModal
 
 LOG = logging.getLogger(__name__)
 
+MOD_ROLE = Config.CONFIG["Discord"]["Roles"]["Mod"]
 
 class TextFields(Enum):
     title = "title"
@@ -73,7 +75,7 @@ class OverlayCommands(app_commands.Group, name="overlay"):
         self.client = client
 
     @app_commands.command(name="set_text")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     @app_commands.describe(field="Overlay field to set")
     @app_commands.describe(text="Text to set field to")
     @app_commands.describe(color="Color of text")
@@ -89,7 +91,7 @@ class OverlayCommands(app_commands.Group, name="overlay"):
         )
 
     @app_commands.command(name="set_media")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     @app_commands.describe(field="Overlay field to set")
     @app_commands.describe(media_url="URL of image to send to frontend")
     @app_commands.describe(media="Attachment image to send to frontend")
@@ -112,7 +114,7 @@ class OverlayCommands(app_commands.Group, name="overlay"):
         )
 
     @app_commands.command(name="set_list")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     @app_commands.describe(field="Overlay field to set")
     @app_commands.describe(csv="Comma separated string of values")
     async def set_list(self, interaction: Interaction, field: ListFields, csv: str):
@@ -124,7 +126,7 @@ class OverlayCommands(app_commands.Group, name="overlay"):
         )
 
     @app_commands.command(name="clear_field")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     @app_commands.describe(field="Overlay field to set")
     async def clear_field(self, interaction: Interaction, field: AllFields):
         """Clear value of field off overlay"""
@@ -134,7 +136,7 @@ class OverlayCommands(app_commands.Group, name="overlay"):
         )
 
     @app_commands.command(name="timer")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     @app_commands.describe(duration="Duration in seconds of timer")
     @app_commands.describe(color="Color of text")
     async def timer(self, interaction: Interaction, duration: int, color: str = None):
@@ -145,7 +147,7 @@ class OverlayCommands(app_commands.Group, name="overlay"):
         await interaction.response.send_message("Overlay update sent!", ephemeral=True)
 
     @app_commands.command(name="toggle")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     @app_commands.describe(switch="On/Off")
     async def toggle_overlay(self, interaction: Interaction, switch: Switch):
         """Toggle overlay to be on or off"""
@@ -159,7 +161,7 @@ class OverlayCommands(app_commands.Group, name="overlay"):
         )
 
     @app_commands.command(name="configure")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     async def configure(self, interaction: Interaction):
         """Paste JSON configuration for overlay directly into modal"""
         await interaction.response.send_modal(OverlayConfigurationModal())

--- a/commands/point_history_commands.py
+++ b/commands/point_history_commands.py
@@ -6,10 +6,12 @@ from discord import (
     Client,
     User,
 )
+from config import YAMLConfig as Config
 
 from controllers.point_history_controller import PointHistoryController
 from db.models import PointsHistory
 
+MOD_ROLE = Config.CONFIG["Discord"]["Roles"]["Mod"]
 
 @app_commands.guild_only()
 class PointHistoryCommands(app_commands.Group, name="points_history"):
@@ -28,7 +30,7 @@ class PointHistoryCommands(app_commands.Group, name="points_history"):
         await interaction.response.send_message(embed=embed)
 
     @app_commands.command(name="user")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     @app_commands.describe(user="User to check point transaction history for")
     async def user(self, interaction: Interaction, user: User):
         """View point transaction history for specified user"""

--- a/commands/reaction_commands.py
+++ b/commands/reaction_commands.py
@@ -1,7 +1,10 @@
 from discord import app_commands, Interaction, Client, User
 from discord.ext.commands import Cog
+from config import YAMLConfig as Config
 from db import DB
 
+
+MOD_ROLE = Config.CONFIG["Discord"]["Roles"]["Mod"]
 
 @app_commands.guild_only()
 class ReactionCommands(app_commands.Group, name="reactions"):
@@ -11,7 +14,7 @@ class ReactionCommands(app_commands.Group, name="reactions"):
         self.client = client
 
     @app_commands.command(name="toggle_emoji")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     @app_commands.describe(user="User ID to remove win from")
     @app_commands.describe(emoji="Emoji to toggle reaction for")
     async def toggle_emoji(self, interaction: Interaction, user: User, emoji: str):
@@ -20,7 +23,7 @@ class ReactionCommands(app_commands.Group, name="reactions"):
         await interaction.response.send_message(f"Reaction toggled {toggle_desc}!")
 
     @app_commands.command(name="set_emoji_reaction_delay")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     @app_commands.describe(delay_time="Delay time in seconds for Robomojis")
     async def set_emoji_reaction_delay(self, interaction: Interaction, delay_time: int):
         """Sets delay time in seconds between Robomoji reactions for users"""

--- a/commands/sync_commands.py
+++ b/commands/sync_commands.py
@@ -1,9 +1,11 @@
 from discord import Interaction, app_commands, Client
+from config import YAMLConfig as Config
 from util.sync_utils import SyncUtils
 import logging
 
 LOG = logging.getLogger(__name__)
 
+MOD_ROLE = Config.CONFIG["Discord"]["Roles"]["Mod"]
 
 @app_commands.guild_only()
 class SyncCommands(app_commands.Group, name="sync"):
@@ -13,7 +15,7 @@ class SyncCommands(app_commands.Group, name="sync"):
         self.client = client
 
     @app_commands.command(name="sync")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     async def sync(self, interaction: Interaction) -> None:
         """Manually sync slash commands to guild"""
         guild = interaction.guild

--- a/commands/temprole_commands.py
+++ b/commands/temprole_commands.py
@@ -7,10 +7,12 @@ from discord import (
     Client,
     User,
 )
+from config import YAMLConfig as Config
 
 from controllers.temprole_controller import TempRoleController
 from util.discord_utils import DiscordUtils
 
+MOD_ROLE = Config.CONFIG["Discord"]["Roles"]["Mod"]
 
 @app_commands.guild_only()
 class TemproleCommands(app_commands.Group, name="temprole"):
@@ -20,7 +22,7 @@ class TemproleCommands(app_commands.Group, name="temprole"):
         self.client = client
 
     @app_commands.command(name="set")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     @app_commands.describe(user="Discord User to assign role to")
     @app_commands.describe(role="Discord Role to assign role to")
     @app_commands.describe(duration="Duration of temprole")
@@ -43,7 +45,7 @@ class TemproleCommands(app_commands.Group, name="temprole"):
         await DiscordUtils.reply(interaction, embed=embed)
 
     @app_commands.command(name="extend")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     @app_commands.describe(user="Discord User to extend role for")
     @app_commands.describe(role="Discord Role to extend duration for")
     @app_commands.describe(duration="Duration to add to temprole")
@@ -66,7 +68,7 @@ class TemproleCommands(app_commands.Group, name="temprole"):
         await DiscordUtils.reply(interaction, embed=embed)
 
     @app_commands.command(name="remove")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     @app_commands.describe(user="Discord User to remove role from")
     @app_commands.describe(role="Discord Role to remove")
     async def remove_role(self, interaction: Interaction, user: User, role: Role):
@@ -86,7 +88,7 @@ class TemproleCommands(app_commands.Group, name="temprole"):
         await DiscordUtils.reply(interaction, embed=embed)
 
     @app_commands.command(name="status")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     @app_commands.describe(user="Discord User to check roles for")
     async def status(self, interaction: Interaction, user: User):
         """See expirations for all temproles currently assigned to given user"""
@@ -98,7 +100,7 @@ class TemproleCommands(app_commands.Group, name="temprole"):
         await TempRoleController.view_temproles(interaction.user, interaction)
 
     @app_commands.command(name="view")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     @app_commands.describe(role="Discord Role to check users for")
     async def view(self, interaction: Interaction, role: Role):
         """See expirations for all users that currently have a given role"""

--- a/commands/vod_commands.py
+++ b/commands/vod_commands.py
@@ -9,6 +9,7 @@ import logging
 PUBLISH_URL = f"{get_base_url()}/publish-vod"
 LOG = logging.getLogger(__name__)
 AUTH_TOKEN = Config.CONFIG["Secrets"]["Server"]["Token"]
+MOD_ROLE = Config.CONFIG["Discord"]["Roles"]["Mod"]
 
 
 @app_commands.guild_only()
@@ -19,7 +20,7 @@ class VodCommands(app_commands.Group, name="vod"):
         self.client = client
 
     @app_commands.command(name="start")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     @app_commands.describe(user="Discord User")
     @app_commands.describe(riotid="riotid")
     @app_commands.describe(rank="rank")
@@ -47,7 +48,7 @@ class VodCommands(app_commands.Group, name="vod"):
         await interaction.response.send_message("VOD start event sent!", ephemeral=True)
 
     @app_commands.command(name="end")
-    @app_commands.checks.has_role("Mod")
+    @app_commands.checks.has_role(MOD_ROLE)
     async def complete(self, interaction: Interaction) -> None:
         """Start a VOD review for the given username"""
         Thread(

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -32,6 +32,7 @@ Discord:
   Roles:
     Bot: 
     Mod: 
+    CM:
   Subscribers:
     12MonthTier3Role:
     6MonthTier3Role:
@@ -54,6 +55,7 @@ Discord:
     RulesAcceptedRole:
     RewardHoursPerReview: 8
     SubmissionChannel:
+    ReviewerRole: 
 Server:
   Host: server
   Port: 3000

--- a/controllers/temprole_controller.py
+++ b/controllers/temprole_controller.py
@@ -71,7 +71,15 @@ class TempRoleController:
     @staticmethod
     async def extend_role(user: User, role: Role, duration: str):
         user_id = user.id
-        extension_duration = timedelta(seconds=timeparse(duration))
+        
+        try:
+            extension_duration = timedelta(seconds=timeparse(duration))
+        except:
+            return (
+                False,
+                "Unable to extend role - please provide a time indicator for duration (e.g. s for seconds, m for minutes)"
+            )
+            
         guild = role.guild
 
         member = guild.get_member(user_id)

--- a/controllers/temprole_controller.py
+++ b/controllers/temprole_controller.py
@@ -28,8 +28,15 @@ class TempRoleController:
             user_id = user.id
         else:
             user_id = user
-        delta = timedelta(seconds=timeparse(duration))
-        expiration = datetime.now() + delta
+        
+        try:
+            delta = timedelta(seconds=timeparse(duration))
+            expiration = datetime.now() + delta
+        except:
+            return (
+                False,
+                "Unable to assing role - please provide a time indicator for duration (e.g. s for seconds, m for minutes)"
+            )
         guild = role.guild
 
         member = guild.get_member(user_id)


### PR DESCRIPTION
Bug fixed: Not providing a time indicator (s, m, etc.) on temprole commands no longer causes an exception
Also added Community Manager (Roles->CM) role and VOD Review Team (VODReview->ReviewerRole) to the config to use the IDs instead of magic strings