### PR TITLE
add 18MonthTier3Role to config.example.yaml

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -36,6 +36,7 @@ Discord:
     Mod: 
     CMChatModerator:
   Subscribers:
+    18MonthTier3Role:
     12MonthTier3Role:
     6MonthTier3Role:
     GiftedTier1Role:


### PR DESCRIPTION
Missing 18MonthTier3Role (added in b90a8cd26154def9d46ec141530eb1d66c9019fa) crashes bot, add to config.example.yaml