### PR TITLE
Move prediction commands out of mod commands

### DIFF
--- a/commands/mod_commands.py
+++ b/commands/mod_commands.py
@@ -10,22 +10,14 @@ from discord import (
     TextChannel,
 )
 from discord.app_commands.errors import AppCommandError, CheckFailure
+from commands import t3_commands
 from controllers.good_morning_controller import (
     GoodMorningController,
     GOOD_MORNING_EXPLANATION,
 )
 from controllers.point_history_controller import PointHistoryController
-from controllers.predictions.close_prediction_controller import (
-    ClosePredictionController,
-)
-from controllers.predictions.payout_prediction_controller import (
-    PayoutPredictionController,
-)
 from db import DB, RaffleType
-from db.models import PredictionChoice, PredictionOutcome
 from models.transaction import Transaction
-from util.discord_utils import DiscordUtils
-from views.predictions.create_predictions_modal import CreatePredictionModal
 from views.raffle.new_raffle_modal import NewRaffleModal
 from views.rewards.add_reward_modal import AddRewardModal
 from controllers.raffle_controller import RaffleController
@@ -505,6 +497,26 @@ class ModCommands(app_commands.Group, name="mod"):
             return
 
         await interaction.response.send_message("Winner removed!")
+
+    @app_commands.command(name="disable_tts_redemptions")
+    @app_commands.checks.has_role(MOD_ROLE)
+    async def disable_tts_redemptions(self, interaction: Interaction) -> None:
+        """Disables the T3 TTS redemption until it is reenabled with the enable command or by a bot restart"""
+        t3_commands.T3_TTS_ENABLED = False
+
+        await interaction.response.send_message(
+            "T3 TTS redemption disabled!", ephemeral=True
+        )
+
+    @app_commands.command(name="enable_tts_redemptions")
+    @app_commands.checks.has_role(MOD_ROLE)
+    async def enable_tts_redemptions(self, interaction: Interaction) -> None:
+        """Enables the T3 TTS redemption"""
+        t3_commands.T3_TTS_ENABLED = True
+
+        await interaction.response.send_message(
+            "T3 TTS redemption enabled!", ephemeral=True
+        )
 
 
 def publish_poll(title, option_one, option_two, option_three, option_four):

--- a/commands/mod_commands.py
+++ b/commands/mod_commands.py
@@ -532,6 +532,7 @@ class ModCommands(app_commands.Group, name="mod"):
             ephemeral=True,
         )
 
+
 def publish_poll(title, option_one, option_two, option_three, option_four):
     payload = {
         "title": title,

--- a/commands/mod_commands.py
+++ b/commands/mod_commands.py
@@ -518,6 +518,19 @@ class ModCommands(app_commands.Group, name="mod"):
             "T3 TTS redemption enabled!", ephemeral=True
         )
 
+    @app_commands.command(name="set_tts_cost")
+    @app_commands.checks.has_role(MOD_ROLE)
+    @app_commands.describe(
+        cost="The cost to use T3 TTS redemption. Set to 10k by default."
+    )
+    async def enable_tts_redemptions(self, interaction: Interaction, cost: int) -> None:
+        """Temporarily sets the cost of the T3 TTS redemption. Cost resets to 10k on bot restarts."""
+        t3_commands.T3_TTS_REQUIRED_POINTS = cost
+
+        await interaction.response.send_message(
+            f"T3 TTS cost set to {cost} points! Will reset to 10k points on bot restart.",
+            ephemeral=True,
+        )
 
 def publish_poll(title, option_one, option_two, option_three, option_four):
     payload = {

--- a/commands/prediction_commands.py
+++ b/commands/prediction_commands.py
@@ -1,0 +1,101 @@
+from typing import Optional
+from discord import (
+    AllowedMentions,
+    app_commands,
+    Interaction,
+    Client,
+)
+from controllers.predictions.close_prediction_controller import (
+    ClosePredictionController,
+)
+from controllers.predictions.payout_prediction_controller import (
+    PayoutPredictionController,
+)
+from db import DB
+from db.models import PredictionChoice, PredictionOutcome
+from views.predictions.create_predictions_modal import CreatePredictionModal
+from config import YAMLConfig as Config
+import logging
+
+LOG = logging.getLogger(__name__)
+JOEL_DISCORD_ID = 112386674155122688
+HOOJ_DISCORD_ID = 82969926125490176
+PREDICTION_AUDIT_CHANNEL = Config.CONFIG["Discord"]["Predictions"]["AuditChannel"]
+TIER3_ROLE_12MO = Config.CONFIG["Discord"]["Subscribers"]["12MonthTier3Role"]
+TIER3_ROLE_18MO = Config.CONFIG["Discord"]["Subscribers"]["18MonthTier3Role"]
+CHAT_MOD_ROLE = Config.CONFIG["Discord"]["Roles"]["CMChatModerator"]
+MOD_ROLE = Config.CONFIG["Discord"]["Roles"]["Mod"]
+
+
+@app_commands.guild_only()
+class PredictionCommands(app_commands.Group, name="prediction"):
+    def __init__(self, tree: app_commands.CommandTree, client: Client) -> None:
+        super().__init__()
+        self.tree = tree
+        self.client = client
+
+    @app_commands.command(name="start_prediction")
+    @app_commands.checks.has_any_role(
+        TIER3_ROLE_12MO, TIER3_ROLE_18MO, MOD_ROLE, CHAT_MOD_ROLE
+    )
+    @app_commands.describe(
+        set_nickname="Whether to prepend users names with their choice"
+    )
+    async def start_prediction(
+        self, interaction: Interaction, set_nickname: Optional[bool] = False
+    ):
+        """Start new prediction"""
+        if DB().has_ongoing_prediction(interaction.guild_id):
+            return await interaction.response.send_message(
+                "There is already an ongoing prediction!", ephemeral=True
+            )
+        await interaction.response.send_modal(
+            CreatePredictionModal(self.client, set_nickname)
+        )
+
+    @app_commands.command(name="refund_prediction")
+    @app_commands.checks.has_role(MOD_ROLE)
+    async def refund_prediction(self, interaction: Interaction):
+        """Refund ongoing prediction, giving users back the points they wagered"""
+        await PayoutPredictionController.refund_prediction(interaction, self.client)
+
+    @app_commands.command(name="close_prediction")
+    @app_commands.checks.has_any_role(
+        TIER3_ROLE_12MO, TIER3_ROLE_18MO, MOD_ROLE, CHAT_MOD_ROLE
+    )
+    async def close_prediction(self, interaction: Interaction):
+        """CLOSE PREDICTION"""
+        await ClosePredictionController.close_prediction(interaction.guild_id)
+        prediction_id = DB().get_ongoing_prediction_id(interaction.guild_id)
+        prediction_message_id = DB().get_prediction_message_id(prediction_id)
+        prediction_channel_id = DB().get_prediction_channel_id(prediction_id)
+        prediction_message = await self.client.get_channel(
+            prediction_channel_id
+        ).fetch_message(prediction_message_id)
+
+        audit_channel = interaction.guild.get_channel(PREDICTION_AUDIT_CHANNEL)
+        await audit_channel.send(
+            f"{interaction.user.mention} closed the current prediction.",
+            allowed_mentions=AllowedMentions.none(),
+        )
+
+        await prediction_message.reply("Prediction closed!")
+        await interaction.response.send_message("Prediction closed!", ephemeral=True)
+
+    @app_commands.command(name="payout_prediction")
+    @app_commands.checks.has_role(MOD_ROLE)
+    @app_commands.describe(option="Option to payout")
+    async def payout_prediction(
+        self, interaction: Interaction, option: PredictionChoice
+    ):
+        """Payout predicton to option left or right"""
+        await PayoutPredictionController.payout_prediction(
+            option, interaction, self.client
+        )
+
+    @app_commands.command(name="redo_payout")
+    @app_commands.checks.has_role(MOD_ROLE)
+    @app_commands.describe(option="Option to payout")
+    async def redo_payout(self, interaction: Interaction, option: PredictionOutcome):
+        """Redo the last prediction's payout"""
+        await PayoutPredictionController.redo_payout(option, interaction, self.client)

--- a/commands/prediction_commands.py
+++ b/commands/prediction_commands.py
@@ -24,6 +24,7 @@ PREDICTION_AUDIT_CHANNEL = Config.CONFIG["Discord"]["Predictions"]["AuditChannel
 TIER3_ROLE_12MO = Config.CONFIG["Discord"]["Subscribers"]["12MonthTier3Role"]
 TIER3_ROLE_18MO = Config.CONFIG["Discord"]["Subscribers"]["18MonthTier3Role"]
 CHAT_MOD_ROLE = Config.CONFIG["Discord"]["Roles"]["CMChatModerator"]
+TRUSTWORTHY = Config.CONFIG["Discord"]["Roles"]["Trustworthy"]
 MOD_ROLE = Config.CONFIG["Discord"]["Roles"]["Mod"]
 
 
@@ -36,7 +37,7 @@ class PredictionCommands(app_commands.Group, name="prediction"):
 
     @app_commands.command(name="start_prediction")
     @app_commands.checks.has_any_role(
-        TIER3_ROLE_12MO, TIER3_ROLE_18MO, MOD_ROLE, CHAT_MOD_ROLE
+        TIER3_ROLE_12MO, TIER3_ROLE_18MO, MOD_ROLE, CHAT_MOD_ROLE, TRUSTWORTHY
     )
     @app_commands.describe(
         set_nickname="Whether to prepend users names with their choice"
@@ -61,7 +62,7 @@ class PredictionCommands(app_commands.Group, name="prediction"):
 
     @app_commands.command(name="close_prediction")
     @app_commands.checks.has_any_role(
-        TIER3_ROLE_12MO, TIER3_ROLE_18MO, MOD_ROLE, CHAT_MOD_ROLE
+        TIER3_ROLE_12MO, TIER3_ROLE_18MO, MOD_ROLE, CHAT_MOD_ROLE, TRUSTWORTHY
     )
     async def close_prediction(self, interaction: Interaction):
         """CLOSE PREDICTION"""

--- a/commands/t3_commands.py
+++ b/commands/t3_commands.py
@@ -36,6 +36,7 @@ T3_ROLE = Config.CONFIG["Discord"]["Subscribers"]["Tier3Role"]
 GIFTED_T3_ROLE = Config.CONFIG["Discord"]["Subscribers"]["GiftedTier3Role"]
 TWITCH_T3_ROLE = Config.CONFIG["Discord"]["Subscribers"]["TwitchTier3Role"]
 T3_TTS_ENABLED = True
+T3_TTS_REQUIRED_POINTS = 10000
 
 
 @app_commands.guild_only()
@@ -67,14 +68,13 @@ class T3Commands(app_commands.Group, name="tier3"):
 
         user_points = DB().get_point_balance(interaction.user.id)
 
-        required_points = 10000
-        if user_points < required_points:
+        if user_points < T3_TTS_REQUIRED_POINTS:
             return await interaction.response.send_message(
-                f"You need {required_points} points to redeem a TTS message. You currently have: {user_points}",
+                f"You need {T3_TTS_REQUIRED_POINTS} points to redeem a TTS message. You currently have: {user_points}",
                 ephemeral=True,
             )
 
         modal = RedeemTTSView(
-            user_points, voice.value, voice.name, required_points, self.client
+            user_points, voice.value, voice.name, T3_TTS_REQUIRED_POINTS, self.client
         )
         await interaction.response.send_modal(modal)

--- a/commands/t3_commands.py
+++ b/commands/t3_commands.py
@@ -15,7 +15,6 @@ import enum
 from db import DB
 from config import YAMLConfig as Config
 import logging
-from util.discord_utils import DiscordUtils
 
 from views.rewards.redeem_tts_view import RedeemTTSView
 
@@ -36,6 +35,7 @@ class VoiceAI(enum.Enum):
 T3_ROLE = Config.CONFIG["Discord"]["Subscribers"]["Tier3Role"]
 GIFTED_T3_ROLE = Config.CONFIG["Discord"]["Subscribers"]["GiftedTier3Role"]
 TWITCH_T3_ROLE = Config.CONFIG["Discord"]["Subscribers"]["TwitchTier3Role"]
+T3_TTS_ENABLED = True
 
 
 @app_commands.guild_only()
@@ -58,6 +58,12 @@ class T3Commands(app_commands.Group, name="tier3"):
     @app_commands.describe(voice="Voice")
     async def flag_vod(self, interaction: Interaction, voice: VoiceAI) -> None:
         """Submit a phrase to be read out on stream by TTS system"""
+
+        if T3_TTS_ENABLED == False:
+            return await interaction.response.send_message(
+                f"The TTS redemption is currently disabled.",
+                ephemeral=True,
+            )
 
         user_points = DB().get_point_balance(interaction.user.id)
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -35,6 +35,7 @@ Discord:
     Bot: 
     Mod: 
     CMChatModerator:
+    Trustworthy:
   Subscribers:
     18MonthTier3Role:
     12MonthTier3Role:

--- a/util/sync_utils.py
+++ b/util/sync_utils.py
@@ -5,6 +5,7 @@ from commands.meme_commands import MemeCommands
 from commands.mod_commands import ModCommands
 from commands.overlay_commands import OverlayCommands
 from commands.point_history_commands import PointHistoryCommands
+from commands.prediction_commands import PredictionCommands
 from commands.reaction_commands import ReactionCommands
 from commands.temprole_commands import TemproleCommands
 from commands.viewer_commands import ViewerCommands
@@ -22,6 +23,7 @@ class SyncUtils:
     ):
         tree.add_command(MemeCommands(tree, client), override=override)
         tree.add_command(ModCommands(tree, client), override=override)
+        tree.add_command(PredictionCommands(tree, client), override=override)
         tree.add_command(ViewerCommands(tree, client), override=override)
         tree.add_command(ManagerCommands(tree, client), override=override)
         tree.add_command(ReactionCommands(tree, client), override=override)


### PR DESCRIPTION
12+ month T3 subs can now run predictions, so moving the commands out of the mod domain makes sense.
This also allows better in-discord slash command permission management.
Furthermore, this increases the capacity for slash commands in the mod domain by the 5 we remove. (There's a limit of 25 commands per domain)

### IMPORTANT
#129 and #130 merge into the PR branch this uses, as they depend on the space we cleared in the mod domain.
_If 129 or 130 are wanted in their current iteration, merge them before merging this PR!_

This PR should be merged in any case, even if 129 or 130 isn't wanted.

I suggest using "Squash and merge" here.