### PR TITLE
Add commands to enable/disable the T3 TTS redemption

### DIFF
--- a/commands/manager_commands.py
+++ b/commands/manager_commands.py
@@ -10,7 +10,6 @@ from discord import (
     User,
 )
 from discord.app_commands.errors import AppCommandError, CheckFailure
-from commands import t3_commands
 from config import YAMLConfig as Config
 import enum
 import logging
@@ -229,23 +228,3 @@ class ManagerCommands(app_commands.Group, name="manager"):
             )
 
         await interaction.response.send_message(returnString, ephemeral=True)
-
-    @app_commands.command(name="disable_tts_redemptions")
-    @app_commands.checks.has_role(MOD_ROLE)
-    async def disable_tts_redemptions(self, interaction: Interaction) -> None:
-        """Disables the T3 TTS redemption until it is reenabled with the enable command or by a bot restart"""
-        t3_commands.T3_TTS_ENABLED = False
-
-        await interaction.response.send_message(
-            "T3 TTS redemption disabled!", ephemeral=True
-        )
-
-    @app_commands.command(name="enable_tts_redemptions")
-    @app_commands.checks.has_role(MOD_ROLE)
-    async def enable_tts_redemptions(self, interaction: Interaction) -> None:
-        """Enables the T3 TTS redemption"""
-        t3_commands.T3_TTS_ENABLED = True
-
-        await interaction.response.send_message(
-            "T3 TTS redemption enabled!", ephemeral=True
-        )

--- a/commands/manager_commands.py
+++ b/commands/manager_commands.py
@@ -10,6 +10,7 @@ from discord import (
     User,
 )
 from discord.app_commands.errors import AppCommandError, CheckFailure
+from commands import t3_commands
 from config import YAMLConfig as Config
 import enum
 import logging
@@ -228,3 +229,23 @@ class ManagerCommands(app_commands.Group, name="manager"):
             )
 
         await interaction.response.send_message(returnString, ephemeral=True)
+
+    @app_commands.command(name="disable_tts_redemptions")
+    @app_commands.checks.has_role(MOD_ROLE)
+    async def disable_tts_redemptions(self, interaction: Interaction) -> None:
+        """Disables the T3 TTS redemption until it is reenabled with the enable command or by a bot restart"""
+        t3_commands.T3_TTS_ENABLED = False
+
+        await interaction.response.send_message(
+            "T3 TTS redemption disabled!", ephemeral=True
+        )
+
+    @app_commands.command(name="enable_tts_redemptions")
+    @app_commands.checks.has_role(MOD_ROLE)
+    async def enable_tts_redemptions(self, interaction: Interaction) -> None:
+        """Enables the T3 TTS redemption"""
+        t3_commands.T3_TTS_ENABLED = True
+
+        await interaction.response.send_message(
+            "T3 TTS redemption enabled!", ephemeral=True
+        )

--- a/commands/mod_commands.py
+++ b/commands/mod_commands.py
@@ -10,22 +10,14 @@ from discord import (
     TextChannel,
 )
 from discord.app_commands.errors import AppCommandError, CheckFailure
+from commands import t3_commands
 from controllers.good_morning_controller import (
     GoodMorningController,
     GOOD_MORNING_EXPLANATION,
 )
 from controllers.point_history_controller import PointHistoryController
-from controllers.predictions.close_prediction_controller import (
-    ClosePredictionController,
-)
-from controllers.predictions.payout_prediction_controller import (
-    PayoutPredictionController,
-)
 from db import DB, RaffleType
-from db.models import PredictionChoice, PredictionOutcome
 from models.transaction import Transaction
-from util.discord_utils import DiscordUtils
-from views.predictions.create_predictions_modal import CreatePredictionModal
 from views.raffle.new_raffle_modal import NewRaffleModal
 from views.rewards.add_reward_modal import AddRewardModal
 from controllers.raffle_controller import RaffleController
@@ -505,6 +497,26 @@ class ModCommands(app_commands.Group, name="mod"):
             return
 
         await interaction.response.send_message("Winner removed!")
+
+    @app_commands.command(name="disable_tts_redemptions")
+    @app_commands.checks.has_role(MOD_ROLE)
+    async def disable_tts_redemptions(self, interaction: Interaction) -> None:
+        """Disables the T3 TTS redemption until it is reenabled with the enable command or by a bot restart"""
+        t3_commands.T3_TTS_ENABLED = False
+
+        await interaction.response.send_message(
+            "T3 TTS redemption disabled!", ephemeral=True
+        )
+
+    @app_commands.command(name="enable_tts_redemptions")
+    @app_commands.checks.has_role(MOD_ROLE)
+    async def enable_tts_redemptions(self, interaction: Interaction) -> None:
+        """Enables the T3 TTS redemption"""
+        t3_commands.T3_TTS_ENABLED = True
+
+        await interaction.response.send_message(
+            "T3 TTS redemption enabled!", ephemeral=True
+        )
 
 
 def publish_poll(title, option_one, option_two, option_three, option_four):

--- a/commands/t3_commands.py
+++ b/commands/t3_commands.py
@@ -15,7 +15,6 @@ import enum
 from db import DB
 from config import YAMLConfig as Config
 import logging
-from util.discord_utils import DiscordUtils
 
 from views.rewards.redeem_tts_view import RedeemTTSView
 
@@ -36,6 +35,7 @@ class VoiceAI(enum.Enum):
 T3_ROLE = Config.CONFIG["Discord"]["Subscribers"]["Tier3Role"]
 GIFTED_T3_ROLE = Config.CONFIG["Discord"]["Subscribers"]["GiftedTier3Role"]
 TWITCH_T3_ROLE = Config.CONFIG["Discord"]["Subscribers"]["TwitchTier3Role"]
+T3_TTS_ENABLED = True
 
 
 @app_commands.guild_only()
@@ -58,6 +58,12 @@ class T3Commands(app_commands.Group, name="tier3"):
     @app_commands.describe(voice="Voice")
     async def flag_vod(self, interaction: Interaction, voice: VoiceAI) -> None:
         """Submit a phrase to be read out on stream by TTS system"""
+
+        if T3_TTS_ENABLED == False:
+            return await interaction.response.send_message(
+                f"The TTS redemption is currently disabled.",
+                ephemeral=True,
+            )
 
         user_points = DB().get_point_balance(interaction.user.id)
 


### PR DESCRIPTION
TTS defaults to enabled after each bot restart

This is V2 of this PR, which has the commands in the mod domain.
Since that space ONLY exists IN PR #128, this PR depends on said PR.
HOWEVER, **IMPORTANTLY**, this PR merges into the dev branch for 128 so this PR needs to be merged first if it is wanted in its current iteration. After that, PR 128 should be merged.