### PR TITLE
Change temprole/vod submission DB deletion logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # RoboBanana Changelog
+## 2024.06.04
+### Additions and Fixes:
+- Add on_member_update event trigger which checks if roles are removed from the user. ([#159](https://github.com/crscillitoe/RoboBanana/pull/159)) (By [Leshy](https://github.com/lorinvzyl))
+    - If the role is related to a remprole assigned to the user, the temprole is removed from the database
+    - if the role is related to vod submissions, the vod submission entry is deleted from the database
 ## 2024.06.01
 ### Additions and Fixes:
 - /manager flag_vod automatically calculates duration required for temprole until desired vod review day ([#158](https://github.com/crscillitoe/RoboBanana/pull/158)) (By [Leshy](https://github.com/lorinvzyl))

--- a/bot.py
+++ b/bot.py
@@ -216,7 +216,6 @@ class RaffleBot(Client):
             await TempRoleController.check_removed_roles(removed_roles, after, GUILD_ID)
 
 
-
 def likely_brain_rot(message: Message) -> (bool, str):
     content = message.content
 

--- a/bot.py
+++ b/bot.py
@@ -209,6 +209,13 @@ class RaffleBot(Client):
     async def on_reaction_add(self, reaction: Reaction, user: Member | User):
         await ReactionController.apply_crowd_mute(reaction)
 
+    async def on_member_update(self, before: Member, after: Member):
+        removed_roles = set(before.roles) - set(after.roles)
+        if removed_roles:
+            removed_roles = [role.id for role in removed_roles]
+            await TempRoleController.check_removed_roles(removed_roles, after, GUILD_ID)
+
+
 
 def likely_brain_rot(message: Message) -> (bool, str):
     content = message.content

--- a/controllers/temprole_controller.py
+++ b/controllers/temprole_controller.py
@@ -236,7 +236,9 @@ class TempRoleController:
             return False, f"{role} is higher than the top role accepted"
 
     @staticmethod
-    async def check_removed_roles(removed_roles : list[int], user: Member, guild_id: int):
+    async def check_removed_roles(
+        removed_roles: list[int], user: Member, guild_id: int
+    ):
         """
         Takes a list of roles that was removed from the user and
         checks if the removed role is part of any temproles assigned
@@ -246,10 +248,15 @@ class TempRoleController:
         """
         temproles = DB().get_user_temproles(user.id, guild_id)
 
-        removed_temproles = [temp for temp in temproles if temp.role_id in removed_roles]
+        removed_temproles = [
+            temp for temp in temproles if temp.role_id in removed_roles
+        ]
 
         for removed_temprole in removed_temproles:
-            if removed_temprole.role_id == APPROVED_ROLE or removed_temprole.role_id == REJECTED_ROLE:
+            if (
+                removed_temprole.role_id == APPROVED_ROLE
+                or removed_temprole.role_id == REJECTED_ROLE
+            ):
                 DB().reset_user(user.id)
             DB().delete_temprole(removed_temprole.id)
 

--- a/controllers/temprole_controller.py
+++ b/controllers/temprole_controller.py
@@ -34,7 +34,6 @@ class TempRoleController:
         else:
             user_id = user
 
-        LOG.info(f"User id: {user_id}")
         try:
             delta = timedelta(seconds=timeparse(duration))
             expiration = datetime.now() + delta
@@ -152,7 +151,6 @@ class TempRoleController:
         except:
             LOG.warn(f"Failed to remove {role} from {member.name}")
             DB().delete_temprole(temprole.id)
-            continue
         return True, f"Removed {role.mention} from {user.mention}."
 
     @staticmethod

--- a/controllers/temprole_controller.py
+++ b/controllers/temprole_controller.py
@@ -145,7 +145,14 @@ class TempRoleController:
         if member is None:
             return False, f"Could not find user {user.mention}!"
 
-        await member.remove_roles(role)
+        # If role is removed, temprole will automatically be removed from the database
+        # through member_update event
+        try:
+            await member.remove_roles(role)
+        except:
+            LOG.warn(f"Failed to remove {role} from {member.name}")
+            DB().delete_temprole(temprole.id)
+            continue
         return True, f"Removed {role.mention} from {user.mention}."
 
     @staticmethod

--- a/views/vod_submission/vod_submission_modal.py
+++ b/views/vod_submission/vod_submission_modal.py
@@ -96,15 +96,13 @@ class NewVodSubmissionModal(Modal, title="Submit a VOD for review!"):
             )
             return
 
-        # Check that we can make the post (they dont have an active submission <1 week old)
+        # Check that we can make the post (they dont have an active submission)
         timestamp = DB().get_latest_timestamp(interaction.user.id)
-        one_week_ago = datetime.now().date() - timedelta(days=6)
 
-        if timestamp is not None and not timestamp.date() <= one_week_ago:
-            # Bad, not enough time
+        if timestamp is not None:
             await interaction.response.send_message(
-                f"You appear to have submitted a VOD less than one week ago. Try"
-                f" again in one week.",
+                f"You appear to have submitted a VOD for this submission week."
+                f"Try again next submission week.",
                 ephemeral=True,
             )
             return


### PR DESCRIPTION
- Add on_member_update event trigger which checks if roles are removed from the user.
  - If the role is related to a temprole assigned to the user, the temprole is removed from the database.
  - If the role is related to vod submissions, the vod submission entry is deleted from the database.

remove_role logic has been changed to a try-catch, where if it succeeds, it will delete the temprole log from the member update, but if it fails, it will delete it in the function itself.