### PR TITLE
Set character limit for additional info section

### DIFF
--- a/views/vod_submission/vod_submission_modal.py
+++ b/views/vod_submission/vod_submission_modal.py
@@ -48,6 +48,7 @@ class NewVodSubmissionModal(Modal, title="Submit a VOD for review!"):
             label="Additional Information (Optional)",
             style=TextStyle.paragraph,
             required=False,
+            max_length=1000,
         )
 
         # Paragraph


### PR DESCRIPTION
- Sets the limit of the additional info section to 1000
Other fields remain at 4000 until the limit of those are figured out, however those are often not a lot and is usually not the reason for submissions failing.