### PR TITLE
Update outdated point_accrual comment

### DIFF
--- a/db/point_accrual.py
+++ b/db/point_accrual.py
@@ -145,7 +145,7 @@ def accrue_channel_points(
             return True
 
         # Ensure points are not accruing on every message
-        # Only award points once per hour
+        # Only award points once per MIN_ACCRUAL_TIME
         channel_points: ChannelPoints = result[0]
         last_accrued: datetime = channel_points.timestamp
         now = datetime.now()


### PR DESCRIPTION
`MIN_ACCRUAL_TIME` is actually 15 minutes, not 1 hour. I've updated the comment to use the variable instead, so that future changes won't make the comment outdated.